### PR TITLE
JSEARCH-39 Fix update token holder balance

### DIFF
--- a/jsearch/common/processing/logs.py
+++ b/jsearch/common/processing/logs.py
@@ -89,7 +89,7 @@ def update_contract_cache(logs: List[Dict[str, Any]], contract_cache: Dict[str, 
     return contract_cache
 
 
-def process_log(log: Dict[str, Any], contract: Dict[str, Any]) -> Dict[str, Any]:
+def decode_token_transfer_event(log: Dict[str, Any], contract: Dict[str, Any]) -> Dict[str, Any]:
     abi = contract['abi']
     try:
         event = contracts.decode_event(abi, log)
@@ -115,7 +115,8 @@ def process_erc20_log(log: Dict[str, Any], contract: Dict[str, Any]) -> Tuple[Di
 
     if token_decimals is None:
         contract_address = contract['address']
-        operations[OPERATION_UPDATE_CONTRACT_INFO].add(contract_address)
+        args_list = (contract_address, )
+        operations[OPERATION_UPDATE_CONTRACT_INFO].add(args_list)
 
     elif event_type == EventTypes.TRANSFER and len(event_args) == TRANSFER_EVENT_INPUT_SIZE:
         from_address, to_address, token_amount = process_erc20_transfer_event(event_args, abi, token_decimals)
@@ -138,7 +139,7 @@ def process_token_transfer_logs(logs, contracts_cache, contract=None) -> Dict[st
     operations = defaultdict(set)
     for log in logs:
         log_contract = contract or contracts_cache[log['address']]
-        log = process_log(log, log_contract)
+        log = decode_token_transfer_event(log, log_contract)
         if is_erc20_compatible(log_contract['abi']):
             log, log_operations = process_erc20_log(log, log_contract)
 


### PR DESCRIPTION
https://jibrelnetwork.atlassian.net/browse/JSEARCH-39

Fix error with stacktrace:
```
post_processing_1       | 2018-11-27 10:30:56,014 ERROR    jsearch.common.processing.operations: Operations is failed with args 0x6531f133e6deebe7f2dce5a0441aa7ef330b4e53
post_processing_1       | Traceback (most recent call last):
post_processing_1       |   File "/usr/local/lib/python3.6/site-packages/jsearch/common/processing/operations.py", line 86, in do_operations_bulk
post_processing_1       |     future.result()
post_processing_1       |   File "/usr/local/lib/python3.6/concurrent/futures/_base.py", line 425, in result
post_processing_1       |     return self.__get_result()
post_processing_1       |   File "/usr/local/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
post_processing_1       |     raise self._exception
post_processing_1       |   File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
post_processing_1       |     result = self.fn(*self.args, **self.kwargs)
post_processing_1       | TypeError: update_token_info() takes from 1 to 2 positional arguments but 42 were given
```