### PR TITLE
Add fast mode to post processing transfers

### DIFF
--- a/jsearch/common/processing/erc20_balances.py
+++ b/jsearch/common/processing/erc20_balances.py
@@ -7,6 +7,7 @@ from web3 import Web3
 
 from jsearch import settings
 from jsearch.common.contracts import NULL_ADDRESS
+from jsearch.common.last_block import LastBlock
 from jsearch.common.rpc import ContractCall, eth_call_batch, eth_call
 from jsearch.syncer.database import MainDBSync
 from jsearch.typing import Log, Abi, Contract, Transfers
@@ -66,11 +67,16 @@ class BalanceUpdate:
 
         is_valid = isinstance(self.value, int)
         if is_valid:
-            changes = db.get_balance_changes_since_block(
-                token=self.token_address,
-                account=self.account_address,
-                block_number=last_block
-            )
+
+            if last_block != LastBlock.LATEST_BLOCK:
+                changes = db.get_balance_changes_since_block(
+                    token=self.token_address,
+                    account=self.account_address,
+                    block_number=last_block
+                )
+            else:
+                changes = 0
+
             balance = self.value + changes
 
             is_valid = balance >= 0
@@ -153,7 +159,7 @@ def update_token_holder_balances(
         db: MainDBSync,
         transfers: Transfers,
         contracts: Dict[str, Contract],
-        last_block: int,
+        last_block: Union[int, str],
         batch_size: int = settings.ETH_NODE_BATCH_REQUEST_SIZE,
 ) -> None:
     updates = set()

--- a/jsearch/common/rpc.py
+++ b/jsearch/common/rpc.py
@@ -113,7 +113,12 @@ class ContractCall:
         self.method = method
         self.args = args
         self.kwargs = kwargs
-        self.block = block and to_hex(block) or 'latest'
+
+        if block:
+            self.block = isinstance(block, int) and to_hex(block) or block
+        else:
+            self.block = 'latest'
+
         self.silent = silent
 
     def encode(self) -> Dict[str, Any]:

--- a/jsearch/post_processing/worker_transfers.py
+++ b/jsearch/post_processing/worker_transfers.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import time
 from itertools import chain
-from typing import List, Dict
+from typing import List, Dict, Union
 
 from jsearch import settings
 from jsearch.common.last_block import LastBlock
@@ -20,7 +20,7 @@ metrics = Metrics()
 logger = logging.getLogger('worker')
 
 
-def worker(contracts: Contracts, transfer_logs: Logs, last_block: int) -> None:
+def worker(contracts: Contracts, transfer_logs: Logs, last_block: Union[int, str]) -> None:
     with MainDBSync(settings.JSEARCH_MAIN_DB) as db:
         start_at = time.time()
         contracts = prefetch_decimals(contracts)
@@ -47,7 +47,7 @@ async def handle_new_transfers(blocks: List[Transfers]):
     metric_blocks = Metric('blocks')
 
     logs = list(chain(*blocks))
-    last_stable_block = await last_block.get_last_stable_block()
+    last_stable_block = await last_block.get()
 
     addresses = list({log['address'] for log in logs})
     contracts = await fetch_contracts(addresses)

--- a/jsearch/tests/test_last_block.py
+++ b/jsearch/tests/test_last_block.py
@@ -19,14 +19,17 @@ def last_block():
 @pytest.mark.asyncio
 async def test_last_block_loaded_from_kafka(last_block, mock_last_block_consumer):
     # given
+    offset = 6
     expected_block_number = 6000000
+
     mock_last_block_consumer({"number": expected_block_number})
+    last_block.offset = offset
 
     # when
     block_number = await last_block.get()
 
     # then
-    assert block_number == expected_block_number
+    assert block_number == expected_block_number - offset
 
 
 @pytest.mark.asyncio
@@ -34,8 +37,9 @@ async def test_last_block_cache(mocker, last_block):
     # given
     mock = CoroutineMock()
 
-    mocker.patch.object(last_block, 'load', mock)
-    last_block.update(number=1)
+    mocker.patch.object(last_block, '_load', mock)
+    last_block.update(number=10)
+    last_block.offset = 6
 
     # when
     # get last block
@@ -43,7 +47,7 @@ async def test_last_block_cache(mocker, last_block):
 
     # then
     # we await what number was cached
-    assert number == 1
+    assert number == 4
 
     mock.assert_not_called()
 

--- a/jsearch/worker/__main__.py
+++ b/jsearch/worker/__main__.py
@@ -124,7 +124,7 @@ async def handle_block_reorganization(record):
 
     logging.info("[REORG] Block number %s, hash %s with reinsert status (%s)", block_number, block_hash, reinserted)
     loop = asyncio.get_event_loop()
-    last_block = await LastBlock().get_last_stable_block()
+    last_block = await LastBlock().get()
 
     async with service.engine.acquire() as connection:
         updates = await get_balance_updates(connection, block_hash, block_number)


### PR DESCRIPTION
At now we can run post processing it two mode:
  - strict - will request balance with offset on 6 block
  - fast - will request balance on latest block

To run try this:
jsearch-post-processing transfers mode --fast