### PR TITLE
JSEARCH-212

### DIFF
--- a/jsearch/api/handlers.py
+++ b/jsearch/api/handlers.py
@@ -237,10 +237,9 @@ async def verify_contract(request):
 
 
 async def get_token_transfers(request):
-    # todo: need to add validation. i'm worried about max size of limit
     storage = request.app['storage']
     params = validate_params(request)
-    contract_address = request.match_info['address']
+    contract_address = request.match_info['address'].lower()
 
     transfers = await storage.get_tokens_transfers(
         address=contract_address,
@@ -255,7 +254,7 @@ async def get_account_token_transfers(request):
     # todo: need to add validation. I'm worried about max size of limit
     storage = request.app['storage']
     params = validate_params(request)
-    account_address = request.match_info['address']
+    account_address = request.match_info['address'].lower()
 
     transfers = await storage.get_account_tokens_transfers(
         address=account_address,
@@ -269,7 +268,7 @@ async def get_account_token_transfers(request):
 async def get_token_holders(request):
     storage = request.app['storage']
     params = validate_params(request)
-    token_address = request.match_info['address']
+    token_address = request.match_info['address'].lower()
 
     holders = await storage.get_tokens_holders(
         address=token_address,
@@ -282,8 +281,8 @@ async def get_token_holders(request):
 
 async def get_account_token_balance(request):
     storage = request.app['storage']
-    token_address = request.match_info['token_address']
-    account_address = request.match_info['address']
+    token_address = request.match_info['token_address'].lower()
+    account_address = request.match_info['address'].lower()
 
     holder = await storage.get_account_token_balance(
         account_address=account_address,
@@ -326,6 +325,7 @@ async def send_raw_transaction(request):
 async def on_new_contracts_added(request):
     data = await request.json()
     address = data['address']
+    address = address and address.lower()
     if settings.ENABLE_RESET_POST_PROCESSING:
         tasks.on_new_contracts_added_task.delay(address)
     return api_success({})

--- a/jsearch/api/helpers.py
+++ b/jsearch/api/helpers.py
@@ -1,6 +1,7 @@
 import json
 
 from aiohttp import web
+
 from jsearch.api.error_code import ErrorCode
 
 DEFAULT_LIMIT = 20


### PR DESCRIPTION
Related to https://jibrelnetwork.atlassian.net/browse/JSEARCH-212.

Always cast to lower case all address hashes.
The main reason is missed cast to lower case.
For example:
  - address on input - `0xB8c77482e45F1F44dE1745F52C74426C631bDD52`
  - address on database - `0xb8c77482e45f1f44de1745f52c74426c631bdd52`