### PR TITLE
Fix 'logging' override for reorgs and wallet workers

### DIFF
--- a/jsearch/common/worker.py
+++ b/jsearch/common/worker.py
@@ -1,0 +1,12 @@
+import mode
+
+
+class NoLoggingOverrideWorker(mode.Worker):
+    """Patched `Worker` with disabled `_setup_logging`.
+
+    Default `mode.Worker` overrides logging configuration. This hack is there to
+    deny this behavior.
+
+    """
+    def _setup_logging(self) -> None:
+        pass

--- a/jsearch/wallet_worker/__main__.py
+++ b/jsearch/wallet_worker/__main__.py
@@ -5,13 +5,13 @@ import backoff
 import click
 import psycopg2
 from aiopg.sa import Engine, create_engine
-from mode import Service, Worker
+from mode import Service
 from sqlalchemy.dialects.postgresql import insert
 
 from jsearch import settings
-from jsearch.common.contracts import ERC20_METHODS_IDS
 from jsearch.common.logs import configure
 from jsearch.common.tables import transactions_t, assets_summary_t, wallet_events_t
+from jsearch.common.worker import NoLoggingOverrideWorker
 from jsearch.service_bus import (
     service_bus,
     ROUTE_WALLET_HANDLE_ASSETS_UPDATE,
@@ -191,7 +191,7 @@ async def handle_assets_update(updates):
 @click.option('--log-level', default='INFO')
 def main(log_level: str) -> None:
     configure(log_level)
-    Worker(service, loglevel=log_level).execute_from_commandline()
+    NoLoggingOverrideWorker(service).execute_from_commandline()
 
 
 def get_event_type(tx_data):

--- a/jsearch/wallet_worker/tests/test_database_service.py
+++ b/jsearch/wallet_worker/tests/test_database_service.py
@@ -3,7 +3,6 @@ import pytest
 
 from jsearch.common.tables import (
     assets_summary_t,
-    assets_transfers_t,
     wallet_events_t,
 )
 from jsearch.wallet_worker.__main__ import DatabaseService

--- a/jsearch/worker/__main__.py
+++ b/jsearch/worker/__main__.py
@@ -30,11 +30,12 @@ import backoff
 import click
 import psycopg2
 from aiopg.sa import Engine, create_engine
-from mode import Service, Worker
+from mode import Service
 
 from jsearch import settings
 from jsearch.common.last_block import LastBlock
 from jsearch.common.logs import configure
+from jsearch.common.worker import NoLoggingOverrideWorker
 from jsearch.multiprocessing import executor
 from jsearch.post_processing.metrics import Metrics
 from jsearch.service_bus import service_bus, ROUTE_HANDLE_REORGANIZATION_EVENTS, ROUTE_HANDLE_LAST_BLOCK
@@ -127,4 +128,4 @@ async def receive_last_block(record: Dict[str, int]):
 @click.option('--log-level', default='INFO')
 def main(log_level: str) -> None:
     configure(log_level)
-    Worker(service, loglevel=log_level).execute_from_commandline()
+    NoLoggingOverrideWorker(service).execute_from_commandline()


### PR DESCRIPTION
By default, [mode](https://github.com/ask/mode) overrides logging configuration on start:

```python
class Worker(Service):
    ...
    async def default_on_first_start(self) -> None:
        self._setup_logging()
        await self.on_execute()
        if self.debug:
            await self._add_monitor()
        self.install_signal_handlers()
```

This PR overrides `Worker._setup_logging()` to do nothing. This way, logs stay configured by `configure_logs`.