### PR TITLE
Do not read 'settings.VERSION' from 'version.txt'

### DIFF
--- a/jsearch/settings.py
+++ b/jsearch/settings.py
@@ -3,9 +3,8 @@ import pathlib
 import socket
 
 BASE_DIR = pathlib.Path(__file__).parent.parent
-VERSION_FILE_PATH = BASE_DIR / 'version.txt'
 
-VERSION = VERSION_FILE_PATH.read_text().strip()
+VERSION = '0.1.3'
 
 JSEARCH_MAIN_DB = os.getenv('JSEARCH_MAIN_DB', 'postgres://localhost/jsearch_main')
 JSEARCH_RAW_DB = os.getenv('JSEARCH_RAW_DB', 'postgres://localhost/jsearch_raw')


### PR DESCRIPTION
As a temporary solution, use a literal instead of reading the file due to the file not being available in a build with 'setup.py' package.