### PR TITLE
JSEARCH-281: Add ability to set log level from env

### DIFF
--- a/jsearch/post_processing/__main__.py
+++ b/jsearch/post_processing/__main__.py
@@ -1,5 +1,6 @@
 # !/usr/bin/env python
 import logging
+import os
 
 import click
 
@@ -16,7 +17,7 @@ MODE_FAST = 'fast'
 
 @click.command()
 @click.argument('action', type=click.Choice(services.ACTION_PROCESS_CHOICES))
-@click.option('--log-level', default='INFO', help="Log level")
+@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'), help="Log level")
 @click.option('--workers', default=30, help="Workers count")
 @click.option('--mode', type=click.Choice([MODE_FAST, MODE_STRICT]), default=MODE_STRICT)
 def main(action: str, log_level: str, workers: int, mode: str) -> None:

--- a/jsearch/syncer/main.py
+++ b/jsearch/syncer/main.py
@@ -1,3 +1,5 @@
+import os
+
 import click
 from jsearch.common import worker
 
@@ -7,7 +9,7 @@ from jsearch.utils import parse_range
 
 
 @click.command()
-@click.option('--log-level', default='INFO', help="Log level")
+@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'), help="Log level")
 @click.option('--sync-range', default=None, help="Blocks range to sync")
 def run(log_level, sync_range):
     logs.configure(log_level)

--- a/jsearch/validation/__main__.py
+++ b/jsearch/validation/__main__.py
@@ -1,6 +1,7 @@
 # !/usr/bin/env python
 import asyncio
 import logging
+import os
 
 import click
 
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 @click.option('--check-balances', is_flag=True)
 @click.option('--show-holders', is_flag=True)
 @click.option('--rewrite', is_flag=True)
-@click.option('--log-level', default='INFO', help="Log level")
+@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'), help="Log level")
 def check(token, check_balances, rewrite, show_holders, log_level):
     logs.configure(log_level)
     loop = asyncio.get_event_loop()

--- a/jsearch/wallet_worker/__main__.py
+++ b/jsearch/wallet_worker/__main__.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from typing import List
 
 import aiomonitor
@@ -302,7 +303,7 @@ def event_from_internal_tx(address, internal_tx_data, tx_data):
 
 
 @click.command()
-@click.option('--log-level', default='INFO')
+@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'))
 def main(log_level: str) -> None:
     configure(log_level)
     loop = asyncio.get_event_loop()

--- a/jsearch/worker/__main__.py
+++ b/jsearch/worker/__main__.py
@@ -24,6 +24,7 @@ Communication scheme for token transfer reorganization.
 """
 import asyncio
 import logging
+import os
 from typing import List, Dict
 
 import backoff
@@ -126,7 +127,7 @@ async def receive_last_block(record: Dict[str, int]):
 
 
 @click.command()
-@click.option('--log-level', default='INFO')
+@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'))
 def main(log_level: str) -> None:
     configure(log_level)
     worker.Worker(


### PR DESCRIPTION
This PR implements an option to set a log level of an application from the environment. To do so, one should manipulate `LOG_LEVEL` variable.