### PR TITLE
JSEARCH-281: Silence 'kafka' and 'aiokafka'

### DIFF
--- a/jsearch/common/logs.py
+++ b/jsearch/common/logs.py
@@ -34,6 +34,10 @@ def configure(log_level: str) -> None:
                 'level': 'CRITICAL',
                 'handlers': ['console']
             },
+            'aiokafka.consumer.fetcher': {
+                'level': 'CRITICAL',
+                'handlers': ['console']
+            },
             'post_processing': {
                 'level': log_level,
                 'handlers': ['console'],


### PR DESCRIPTION
This PR silences `kafka` and `aiokafka` loggers.

Right now, `kafka` and `aiokafka` constantly logs thousands of messages with `ERROR` level when all Kafka nodes are down. All those log messages are sent to Sentry and cause it to be bloated with connection errors.

Errors for reference:

* `aiokafka`:
```
ERROR:aiokafka.consumer.fetcher:Failed fetch messages from 1001: NodeNotReadyError: Attempt to send a request to node which is not ready (node id 1001).
ERROR:aiokafka:Unable connect to node with id 1001: [Errno 111] Connect call failed ('172.31.0.3', 9092)
ERROR:aiokafka:Unable to update metadata from [1001]
ERROR:aiokafka:Unable connect to node with id 1001: [Errno 111] Connect call failed ('172.31.0.3', 9092)
ERROR:aiokafka.consumer.fetcher:Failed fetch messages from 1001: NodeNotReadyError: Attempt to send a request to node which is not ready (node id 1001).
ERROR:aiokafka:Unable connect to node with id 1001: [Errno 111] Connect call failed ('172.31.0.3', 9092)
ERROR:aiokafka:Unable to update metadata from [1001]
ERROR:aiokafka:Unable connect to node with id 1001: [Errno 111] Connect call failed ('172.31.0.3', 9092)
ERROR:aiokafka.consumer.fetcher:Failed fetch messages from 1001: NodeNotReadyError: Attempt to send a request to node which is not ready (node id 1001).
ERROR:aiokafka:Unable connect to node with id 1001: [Errno 111] Connect call failed ('172.31.0.3', 9092)
ERROR:aiokafka:Unable to update metadata from [1001]
```
* `kafka`:
```
ERROR:kafka.conn:DNS lookup failed for ae067d3d2c33:9092 (AddressFamily.AF_UNSPEC)
WARNING:kafka.conn:<BrokerConnection node_id=1001 host=ae067d3d2c33:9092 <disconnected> [IPv4 ('172.31.0.3', 9092)]>: Duplicate close() with error: KafkaConnectionError: DNS failure
WARNING:kafka.conn:DNS lookup failed for ae067d3d2c33:9092, exception was [Errno -2] Name or service not known. Is your advertised.listeners (called advertised.host.name before Kafka 9) correct and resolvable?
ERROR:kafka.conn:DNS lookup failed for ae067d3d2c33:9092 (AddressFamily.AF_UNSPEC)
WARNING:kafka.conn:<BrokerConnection node_id=1001 host=ae067d3d2c33:9092 <disconnected> [IPv4 ('172.31.0.3', 9092)]>: Duplicate close() with error: KafkaConnectionError: DNS failure
WARNING:kafka.conn:DNS lookup failed for ae067d3d2c33:9092, exception was [Errno -2] Name or service not known. Is your advertised.listeners (called advertised.host.name before Kafka 9) correct and resolvable?
ERROR:kafka.conn:DNS lookup failed for ae067d3d2c33:9092 (AddressFamily.AF_UNSPEC)
WARNING:kafka.conn:<BrokerConnection node_id=1001 host=ae067d3d2c33:9092 <disconnected> [IPv4 ('172.31.0.3', 9092)]>: Duplicate close() with error: KafkaConnectionError: DNS failure
WARNING:kafka.conn:DNS lookup failed for ae067d3d2c33:9092, exception was [Errno -2] Name or service not known. Is your advertised.listeners (called advertised.host.name before Kafka 9) correct and resolvable?
```
