### PR TITLE
JSEARCH-332: Add ability to disable JSON formatter

### DIFF
--- a/jsearch/api/app.py
+++ b/jsearch/api/app.py
@@ -88,7 +88,11 @@ async def make_app():
 
     app.router.add_static('/docs', swagger_ui_path)
     setup_swagger(app, swagger_from_file=swagger_file)
-    logs.configure(settings.LOG_LEVEL)
+
+    logs.configure(
+        log_level=settings.LOG_LEVEL,
+        formatter_class=logs.select_formatter_class(settings.NO_JSON_FORMATTER),
+    )
 
     return app
 

--- a/jsearch/common/logs.py
+++ b/jsearch/common/logs.py
@@ -8,13 +8,20 @@ from jsearch import settings
 sentry_sdk.init(settings.RAVEN_DSN)
 
 
-def configure(log_level: str) -> None:
+def select_formatter_class(no_json_formatter: bool) -> str:
+    if no_json_formatter:
+        return 'logging.Formatter'
+
+    return 'pythonjsonlogger.jsonlogger.JsonFormatter'
+
+
+def configure(log_level: str, formatter_class: str) -> None:
     config = {
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
             'default': {
-                'class': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+                'class': formatter_class,
                 'format': '%(asctime)-15s %(levelname)-8s %(name)s: %(message)s',
             }
         },

--- a/jsearch/pending_syncer/main.py
+++ b/jsearch/pending_syncer/main.py
@@ -1,20 +1,18 @@
-import os
-
 import click
-from jsearch.utils import parse_range
 
 from jsearch import settings
-
 from jsearch.common import logs, worker
 from jsearch.common.structs import SyncRange
 from jsearch.pending_syncer import services
+from jsearch.utils import parse_range
 
 
 @click.command()
-@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'), help="Log level")
+@click.option('--log-level', settings.LOG_LEVEL, help="Log level")
+@click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
 @click.option('--sync-range', default=None, help="Log level")
-def run(log_level, sync_range):
-    logs.configure(log_level)
+def run(log_level, no_json_formatter, sync_range):
+    logs.configure(log_level=log_level, formatter_class=logs.select_formatter_class(no_json_formatter))
 
     # TODO (Nick Gashkov): Move `SyncRange` to the `parse_range` function. I
     # didn't do it right now because this causes slight refactoring of the

--- a/jsearch/post_processing/__main__.py
+++ b/jsearch/post_processing/__main__.py
@@ -1,9 +1,9 @@
 # !/usr/bin/env python
 import logging
-import os
 
 import click
 
+from jsearch import settings
 from jsearch.common import logs, worker
 from jsearch.common.last_block import LastBlock
 from jsearch.multiprocessing import executor
@@ -17,11 +17,12 @@ MODE_FAST = 'fast'
 
 @click.command()
 @click.argument('action', type=click.Choice(services.ACTION_PROCESS_CHOICES))
-@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'), help="Log level")
+@click.option('--log-level', settings.LOG_LEVEL, help="Log level")
+@click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
 @click.option('--workers', default=30, help="Workers count")
 @click.option('--mode', type=click.Choice([MODE_FAST, MODE_STRICT]), default=MODE_STRICT)
-def main(action: str, log_level: str, workers: int, mode: str) -> None:
-    logs.configure(log_level)
+def main(action: str, log_level: str, no_json_formatter: bool, workers: int, mode: str) -> None:
+    logs.configure(log_level=log_level, formatter_class=logs.select_formatter_class(no_json_formatter))
     executor.init(workers)
 
     if mode == MODE_FAST:

--- a/jsearch/settings.py
+++ b/jsearch/settings.py
@@ -12,6 +12,7 @@ JSEARCH_MAIN_DB = os.getenv('JSEARCH_MAIN_DB', 'postgres://localhost/jsearch_mai
 JSEARCH_RAW_DB = os.getenv('JSEARCH_RAW_DB', 'postgres://localhost/jsearch_raw')
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
+NO_JSON_FORMATTER = bool(int(os.getenv('NO_JSON_FORMATTER', '0')))
 
 # can get list of connection.
 # examples:

--- a/jsearch/syncer/main.py
+++ b/jsearch/syncer/main.py
@@ -1,18 +1,18 @@
-import os
-
 import click
-from jsearch.common import worker
 
+from jsearch import settings
 from jsearch.common import logs
+from jsearch.common import worker
 from jsearch.syncer import services
 from jsearch.utils import parse_range
 
 
 @click.command()
-@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'), help="Log level")
+@click.option('--log-level', default=settings.LOG_LEVEL, help="Log level")
+@click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
 @click.option('--sync-range', default=None, help="Blocks range to sync")
-def run(log_level, sync_range):
-    logs.configure(log_level)
+def run(log_level, no_json_formatter, sync_range):
+    logs.configure(log_level=log_level, formatter_class=logs.select_formatter_class(no_json_formatter))
 
     worker.Worker(
         services.SyncerService(sync_range=parse_range(sync_range)),

--- a/jsearch/validation/__main__.py
+++ b/jsearch/validation/__main__.py
@@ -1,10 +1,10 @@
 # !/usr/bin/env python
 import asyncio
 import logging
-import os
 
 import click
 
+from jsearch import settings
 from jsearch.common import logs
 from jsearch.service_bus import service_bus
 from jsearch.validation.balances import check_token_holder_balances, show_statistics, show_top_holders
@@ -18,9 +18,18 @@ logger = logging.getLogger(__name__)
 @click.option('--check-balances', is_flag=True)
 @click.option('--show-holders', is_flag=True)
 @click.option('--rewrite', is_flag=True)
-@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'), help="Log level")
-def check(token, check_balances, rewrite, show_holders, log_level):
-    logs.configure(log_level)
+@click.option('--log-level', settings.LOG_LEVEL, help="Log level")
+@click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
+def check(
+        token: str,
+        check_balances: bool,
+        rewrite: bool,
+        show_holders: bool,
+        log_level: str,
+        no_json_formatter: bool,
+) -> None:
+
+    logs.configure(log_level=log_level, formatter_class=logs.select_formatter_class(no_json_formatter))
     loop = asyncio.get_event_loop()
 
     tokens = service_bus.get_contracts(addresses=[token])

--- a/jsearch/wallet_worker/__main__.py
+++ b/jsearch/wallet_worker/__main__.py
@@ -1,12 +1,11 @@
 import asyncio
 import logging
-import os
 
 import aiomonitor
 import click
 
-from jsearch.common import worker
-from jsearch.common.logs import configure
+from jsearch import settings
+from jsearch.common import worker, logs
 from jsearch.service_bus import (
     service_bus,
     ROUTE_WALLET_HANDLE_ASSETS_UPDATE,
@@ -92,9 +91,10 @@ async def handle_assets_update(updates):
 
 
 @click.command()
-@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'))
-def main(log_level: str) -> None:
-    configure(log_level)
+@click.option('--log-level', settings.LOG_LEVEL)
+@click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
+def main(log_level: str, no_json_logging: bool) -> None:
+    logs.configure(log_level=log_level, formatter_class=logs.select_formatter_class(no_json_logging))
     loop = asyncio.get_event_loop()
     with aiomonitor.start_monitor(loop=loop):
         worker.Worker(

--- a/jsearch/worker/__main__.py
+++ b/jsearch/worker/__main__.py
@@ -24,7 +24,6 @@ Communication scheme for token transfer reorganization.
 """
 import asyncio
 import logging
-import os
 from typing import List, Dict
 
 import backoff
@@ -34,9 +33,9 @@ from aiopg.sa import Engine, create_engine
 from mode import Service
 
 from jsearch import settings
-from jsearch.common.last_block import LastBlock
-from jsearch.common.logs import configure
+from jsearch.common import logs
 from jsearch.common import worker
+from jsearch.common.last_block import LastBlock
 from jsearch.multiprocessing import executor
 from jsearch.service_bus import service_bus, ROUTE_HANDLE_REORGANIZATION_EVENTS, ROUTE_HANDLE_LAST_BLOCK
 from jsearch.syncer.database_queries.assets_summary import insert_or_update_assets_summary
@@ -124,9 +123,10 @@ async def receive_last_block(record: Dict[str, int]):
 
 
 @click.command()
-@click.option('--log-level', default=os.getenv('LOG_LEVEL', 'INFO'))
-def main(log_level: str) -> None:
-    configure(log_level)
+@click.option('--log-level', settings.LOG_LEVEL)
+@click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
+def main(log_level: str, no_json_logging: bool) -> None:
+    logs.configure(log_level=log_level, formatter_class=logs.select_formatter_class(no_json_logging))
     worker.Worker(
         service,
         ApiService(),


### PR DESCRIPTION
This PR adds an ability to use default `logging.Formatter` instead of a JSON one. This can be achieved either by adding an option key or by setting an environment variable:

```bash
$ jsearch-syncer --no-json-formatter
$ NO_JSON_FORMATTER=1 jsearch-syncer
```

The same policy applies for the rest of entry points:

```bash
$ NO_JSON_FORMATTER=1 gunicorn -c gunicorn-conf.py jsearch.api.app:make_app
$ NO_JSON_FORMATTER=1 jsearch-syncer
$ NO_JSON_FORMATTER=1 jsearch-syncer-pending
$ NO_JSON_FORMATTER=1 jsearch-post-processing logs
$ NO_JSON_FORMATTER=1 jsearch-post-processing transfers
$ NO_JSON_FORMATTER=1 jsearch-check
$ NO_JSON_FORMATTER=1 jsearch-worker
$ NO_JSON_FORMATTER=1 jsearch-wallet-worker
```