### PR TITLE
JSEARCH-332: Fix invalid 'click' option declaration

### DIFF
--- a/jsearch/pending_syncer/main.py
+++ b/jsearch/pending_syncer/main.py
@@ -8,7 +8,7 @@ from jsearch.utils import parse_range
 
 
 @click.command()
-@click.option('--log-level', settings.LOG_LEVEL, help="Log level")
+@click.option('--log-level', default=settings.LOG_LEVEL, help="Log level")
 @click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
 @click.option('--sync-range', default=None, help="Log level")
 def run(log_level, no_json_formatter, sync_range):

--- a/jsearch/post_processing/__main__.py
+++ b/jsearch/post_processing/__main__.py
@@ -17,7 +17,7 @@ MODE_FAST = 'fast'
 
 @click.command()
 @click.argument('action', type=click.Choice(services.ACTION_PROCESS_CHOICES))
-@click.option('--log-level', settings.LOG_LEVEL, help="Log level")
+@click.option('--log-level', default=settings.LOG_LEVEL, help="Log level")
 @click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
 @click.option('--workers', default=30, help="Workers count")
 @click.option('--mode', type=click.Choice([MODE_FAST, MODE_STRICT]), default=MODE_STRICT)

--- a/jsearch/validation/__main__.py
+++ b/jsearch/validation/__main__.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @click.option('--check-balances', is_flag=True)
 @click.option('--show-holders', is_flag=True)
 @click.option('--rewrite', is_flag=True)
-@click.option('--log-level', settings.LOG_LEVEL, help="Log level")
+@click.option('--log-level', default=settings.LOG_LEVEL, help="Log level")
 @click.option('--no-json-formatter', is_flag=True, default=settings.NO_JSON_FORMATTER, help='Use default formatter')
 def check(
         token: str,


### PR DESCRIPTION
This PR fixes invalid `click` option declaration, which leads to a following error:

```
pending_syncer_1             | Traceback (most recent call last):
pending_syncer_1             |   File "/usr/local/bin/jsearch-syncer-pending", line 10, in <module>
pending_syncer_1             |     sys.exit(run())
pending_syncer_1             |   File "/usr/local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
pending_syncer_1             |     return self.main(*args, **kwargs)
pending_syncer_1             |   File "/usr/local/lib/python3.6/site-packages/click/core.py", line 717, in main
pending_syncer_1             |     rv = self.invoke(ctx)
pending_syncer_1             |   File "/usr/local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
pending_syncer_1             |     return ctx.invoke(self.callback, **ctx.params)
pending_syncer_1             |   File "/usr/local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
pending_syncer_1             |     return callback(*args, **kwargs)
pending_syncer_1             | TypeError: run() got an unexpected keyword argument 'INFO'
```