### PR TITLE
Rename DBs, used for testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   tests:
     &tests
     depends_on:
-      - main_db
-      - raw_db
+      - tests_main_db
+      - tests_raw_db
     build:
       context: .
       dockerfile: Dockerfile
@@ -16,8 +16,8 @@ services:
     entrypoint: /bin/sh
     command: -c "flake8 && pytest"
     environment:
-      JSEARCH_MAIN_DB_TEST: postgres://postgres:postgres@main_db/jsearch_main
-      JSEARCH_RAW_DB_TEST: postgres://postgres:postgres@raw_db/jsearch_raw
+      JSEARCH_MAIN_DB_TEST: postgres://postgres:postgres@tests_main_db/jsearch_main
+      JSEARCH_RAW_DB_TEST: postgres://postgres:postgres@tests_raw_db/jsearch_raw
     env_file:
       - config/dev.env
 
@@ -30,7 +30,7 @@ services:
       - ./:/app
 
 
-  raw_db:
+  tests_raw_db:
     image: postgres:11.0-alpine
     container_name: jsearch_raw_db
     environment:
@@ -38,7 +38,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: jsearch_raw
 
-  main_db:
+  tests_main_db:
     image: postgres:11.0-alpine
     container_name: jsearch_main_db
     environment:


### PR DESCRIPTION
This PR renames tests' databases' names to avoid a collision between tests' databases and databases from the meta [docker-compose.yml](https://github.com/jibrelnetwork/jsearch/blob/9c323a9e73e8128a23557e8422784bf8ac4d7596/docker-compose.yml#L4):

```
ERROR: for raw_db  Cannot create container for service raw_db: Conflict. The container name "/jsearch_raw_db" is already in use by container "1e046bbca88b9d921797acef3d08dc0e102087ecc5b283ed78c2f6674bc331c4". You have to remove (or rename) that container to be able to reuse that name.
ERROR: Encountered errors while bringing up the project.
```