### PR TITLE
JSEARCH-344: Update internal TXs index

### DIFF
--- a/jsearch/common/migrations/versions/389563d0baee_drop_internal_txs_pk_without_call_depth.py
+++ b/jsearch/common/migrations/versions/389563d0baee_drop_internal_txs_pk_without_call_depth.py
@@ -1,0 +1,34 @@
+"""drop_internal_txs_pk_without_call_depth
+
+Revision ID: 389563d0baee
+Revises: e14bb549ec28
+Create Date: 2019-06-28 09:58:02.367000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from jsearch.common import tables
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '389563d0baee'
+down_revision = 'e14bb549ec28'
+branch_labels = None
+depends_on = None
+
+
+UP_SQL = """
+ALTER TABLE internal_transactions DROP CONSTRAINT internal_transactions_pkey;
+"""
+
+DOWN_SQL = """
+ALTER TABLE internal_transactions ADD PRIMARY KEY USING INDEX internal_transactions_pkey;
+"""
+
+
+def upgrade():
+    op.execute(UP_SQL)
+
+
+def downgrade():
+    op.execute(DOWN_SQL)

--- a/jsearch/common/migrations/versions/796abd73d069_add_internal_txs_pk_with_call_depth.py
+++ b/jsearch/common/migrations/versions/796abd73d069_add_internal_txs_pk_with_call_depth.py
@@ -1,0 +1,34 @@
+"""add_internal_txs_pk_with_call_depth
+
+Revision ID: 796abd73d069
+Revises: 995ab1bc1218
+Create Date: 2019-06-28 10:49:19.991463
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from jsearch.common import tables
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '796abd73d069'
+down_revision = '995ab1bc1218'
+branch_labels = None
+depends_on = None
+
+
+UP_SQL = """
+ALTER TABLE internal_transactions ADD PRIMARY KEY USING INDEX internal_transactions_pkey;
+"""
+
+DOWN_SQL = """
+ALTER TABLE internal_transactions DROP CONSTRAINT internal_transactions_pkey;
+"""
+
+
+def upgrade():
+    op.execute(UP_SQL)
+
+
+def downgrade():
+    op.execute(DOWN_SQL)

--- a/jsearch/common/migrations/versions/995ab1bc1218_add_internal_txs_index_with_call_depth.py
+++ b/jsearch/common/migrations/versions/995ab1bc1218_add_internal_txs_index_with_call_depth.py
@@ -1,0 +1,38 @@
+"""add_internal_txs_index_with_call_depth
+
+Revision ID: 995ab1bc1218
+Revises: 389563d0baee
+Create Date: 2019-06-28 10:42:27.712813
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from jsearch.common import tables
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '995ab1bc1218'
+down_revision = '389563d0baee'
+branch_labels = None
+depends_on = None
+
+
+UP_SQL = """
+CREATE UNIQUE INDEX CONCURRENTLY internal_transactions_pkey
+  ON internal_transactions(block_hash, parent_tx_hash, transaction_index, call_depth);
+"""
+
+DOWN_SQL = """
+CREATE UNIQUE INDEX CONCURRENTLY internal_transactions_pkey
+  ON internal_transactions(block_hash, parent_tx_hash, transaction_index);
+"""
+
+
+def upgrade():
+    op.execute('COMMIT')
+    op.execute(UP_SQL)
+
+
+def downgrade():
+    op.execute('COMMIT')
+    op.execute(DOWN_SQL)


### PR DESCRIPTION
This PR fixes an [error](https://sentry.io/organizations/jibrel-network-dev/issues/1088308158/?project=1490818&query=is%3Aunresolved) with `UNIQUE` constraint violation.

The following migration is split into three steps to allow concurrent index build:

```sql
# up.sql

ALTER TABLE internal_transactions DROP CONSTRAINT internal_transactions_pkey;
CREATE UNIQUE INDEX CONCURRENTLY internal_transactions_pkey
  ON internal_transactions(block_hash, parent_tx_hash, transaction_index, call_depth);
ALTER TABLE internal_transactions ADD PRIMARY KEY USING INDEX internal_transactions_pkey;
```

```sql
# down.sql

ALTER TABLE internal_transactions DROP CONSTRAINT internal_transactions_pkey;
CREATE UNIQUE INDEX CONCURRENTLY internal_transactions_pkey
  ON internal_transactions(block_hash, parent_tx_hash, transaction_index);
ALTER TABLE internal_transactions ADD PRIMARY KEY USING INDEX internal_transactions_pkey;
```