### PR TITLE
JSEARCH-356

### DIFF
--- a/jsearch/common/worker.py
+++ b/jsearch/common/worker.py
@@ -1,6 +1,6 @@
-import mode
+import asyncio
 
-from jsearch import utils
+import mode
 
 
 class Worker(mode.Worker):
@@ -8,8 +8,9 @@ class Worker(mode.Worker):
     Default `mode.Worker` overrides logging configuration. This hack is there to
     deny this behavior.
     """
-    async def on_shutdown(self) -> None:
-        await utils.shutdown()
 
     def _setup_logging(self) -> None:
         pass
+
+    def schedule_shutdown(self):
+        asyncio.ensure_future(self.stop())

--- a/jsearch/syncer/main.py
+++ b/jsearch/syncer/main.py
@@ -14,10 +14,10 @@ from jsearch.utils import parse_range
 def run(log_level, no_json_formatter, sync_range):
     logs.configure(log_level=log_level, formatter_class=logs.select_formatter_class(no_json_formatter))
 
-    worker.Worker(
-        services.SyncerService(sync_range=parse_range(sync_range)),
-        services.ApiService(),
-    ).execute_from_commandline()
+    syncer = services.SyncerService(sync_range=parse_range(sync_range))
+    syncer.add_dependency(services.ApiService())
+
+    worker.Worker(syncer).execute_from_commandline()
 
 
 if __name__ == '__main__':

--- a/jsearch/syncer/manager.py
+++ b/jsearch/syncer/manager.py
@@ -217,6 +217,7 @@ class Manager:
                 }
             )
             await asyncio.sleep(10)
+            self._running = False
             return
 
         if next_event is None:

--- a/jsearch/syncer/services/syncer.py
+++ b/jsearch/syncer/services/syncer.py
@@ -33,3 +33,7 @@ class SyncerService(mode.Service):
         exception = await self.manager.wait()
         if exception:
             await self.crash(exception)
+
+        await self.stop()
+        # we schedule shutdown on root Worker
+        self.beacon.root.data.schedule_shutdown()


### PR DESCRIPTION
When syncer will finish processing in specified range,
then it will shutdown with exit code 0.

It will happen only if we specify until block in --sync-range.
If we specify only start block - we will wait new chain
events in range.

Proof of exit code:
<img width="1518" alt="Screenshot 2019-07-03 at 00 11 58" src="https://user-images.githubusercontent.com/2203207/60547704-0edb8c00-9d29-11e9-8678-fd0892ea4ea1.png">
