### PR TITLE
JSEARCH-386 Syncer: fix hangs

### DIFF
--- a/jsearch/syncer/processor.py
+++ b/jsearch/syncer/processor.py
@@ -3,7 +3,7 @@ from copy import copy
 
 import re
 import time
-from typing import NamedTuple, Dict, Any, List, Tuple
+from typing import NamedTuple, Dict, Any, List, Tuple, Optional
 
 from jsearch.common import contracts
 from jsearch.common.processing import wallet
@@ -56,8 +56,11 @@ class SyncProcessor:
         self.raw_db = raw_db
         self.main_db = main_db
 
-    async def sync_block(self, block_hash: str, block_number: int = None,
-                         is_forked: bool = False, chain_event: Dict = None) -> bool:
+    async def sync_block(self,
+                         block_hash: str,
+                         block_number: Optional[int] = None,
+                         is_forked: bool = False,
+                         chain_event: Optional[Dict[str, Any]] = None) -> bool:
         """
         Args:
             block_hash: number of block to sync
@@ -72,10 +75,6 @@ class SyncProcessor:
         await self.raw_db.connect()
 
         start_time = time.monotonic()
-        is_block_exist = await self.main_db.is_block_exist(block_hash)
-        if is_block_exist is True:
-            logger.debug("Block already exists", extra={'hash': block_hash})
-            return False
 
         receipts = await self.raw_db.get_block_receipts(block_hash)
         if receipts is None:


### PR DESCRIPTION
Syncer crashes on case when we have 2 chain events with same type created and same block_hash.

As decision - PR, when we skip process such event and same them to database to avoid eternal loop.

Proof from RAW DB.

```
jsearch-raw=> select id, block_hash, type, node_id from chain_events where id = 8206372 or id = 8211174;
   id    |                             block_hash                             |  type   |                              node_id
---------+--------------------------------------------------------------------+---------+--------------------------------------------------------------------
 8206372 | 0x3248deb28b3923a608f72b908462643f69ce97065ae4d0d2540c5698934efd7a | created | 0x83f47b4ec7fc8a709e649df7fd2a77d34119dbd0a2e47b5430e85033108142e9
 8211174 | 0x3248deb28b3923a608f72b908462643f69ce97065ae4d0d2540c5698934efd7a | created | 0x83f47b4ec7fc8a709e649df7fd2a77d34119dbd0a2e47b5430e85033108142e9
(2 rows)
```