### PR TITLE
JSEARCH-396: Fix data corruption with parallel processing

### DIFF
--- a/jsearch/syncer/database_queries/pending_transactions.py
+++ b/jsearch/syncer/database_queries/pending_transactions.py
@@ -19,7 +19,8 @@ def insert_or_update_pending_tx_q(pending_tx: Dict[str, Any]) -> Query:
             'timestamp': insert_query.excluded.timestamp,
             'removed': insert_query.excluded.removed,
             'node_id': insert_query.excluded.node_id,
-        }
+        },
+        where=pending_transactions_t.c.last_synced_id < insert_query.excluded.last_synced_id,
     )
 
     return insert_query


### PR DESCRIPTION
This PR fixes data corruption if multiple instances of the Pending TXs Syncer are run in parallel.

More details about previous implementation can be found in [Confluence](https://jibrelnetwork.atlassian.net/wiki/spaces/JSEARCH/pages/944800087/Syncing+TX+pool), section _"No ability to run multiple workers"_.