### PR TITLE
JSEARCH-529: Fix DB connection blockage for 'v1/receipts/{tx_hash}'

### DIFF
--- a/jsearch/api/storage.py
+++ b/jsearch/api/storage.py
@@ -483,16 +483,15 @@ class Storage:
                 return None
             row = dict(row)
             del row['is_forked']
-            row['logs'] = await self.get_logs(row['transaction_hash'])
+            row['logs'] = await self.get_logs(conn, row['transaction_hash'])
             return models.Receipt(**row)
 
-    async def get_logs(self, tx_hash: str) -> List[models.Log]:
+    async def get_logs(self, conn, tx_hash: str) -> List[models.Log]:
         fields = models.Log.select_fields()
         query = f"SELECT {fields} FROM logs WHERE transaction_hash=$1 ORDER BY log_index"
 
-        async with self.pool.acquire() as conn:
-            rows = await conn.fetch(query, tx_hash)
-            return [models.Log(**r) for r in rows]
+        rows = await conn.fetch(query, tx_hash)
+        return [models.Log(**r) for r in rows]
 
     async def get_account_logs(
             self,


### PR DESCRIPTION
This PR fixes DB connection blockage when 200+ users are requesting the same endpoint.

When lots of users are requesting `v1/receipts/{tx_hash}`, connections pool run out of connections to acquire and no more requests to **MainDB** can be performed:

```
SELECT pid, age(clock_timestamp(), query_start), usename, query, state
FROM pg_stat_activity
WHERE query NOT ILIKE '%pg_stat_activity%'
ORDER BY query_start desc;

  pid  |       age       | usename  |                      query                       | state
-------+-----------------+----------+--------------------------------------------------+-------
...
 11466 | 00:04:08.074998 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11460 | 00:04:08.077415 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11467 | 00:04:08.125463 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11459 | 00:04:08.127345 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11465 | 00:04:08.148197 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11461 | 00:04:08.150055 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11463 | 00:04:08.152658 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11462 | 00:04:08.155698 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11464 | 00:04:08.156492 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
 11468 | 00:04:08.156556 | postgres | SELECT * FROM receipts WHERE transaction_hash=$1 | idle
...
```