### PR TITLE
JSEARCH-446 Prevent address mismatch filtration.

### DIFF
--- a/jsearch/syncer/database/raw.py
+++ b/jsearch/syncer/database/raw.py
@@ -139,8 +139,8 @@ class RawDB(DBWrapper):
         SELECT
             "block_number",
             "block_hash",
-            "token_address" as token,
-            "holder_address" as account,
+            lower("token_address") as token,
+            lower("holder_address") as account,
             "balance"::bigint
         FROM token_holders
         WHERE block_hash = %s;


### PR DESCRIPTION
Prevent case when we save **address** and **token_adress** as mixed lower and upper value.

Case proof from **dev** server:
```
postgres=# select lower(address), lower(asset_address), address, asset_address from assets_summary where address = '0x6a32acc46EE04673A906d7DC8975AcF9d3F49E3E' limit 10;
                   lower                    |                   lower                    |                  address                   |               asset_address
--------------------------------------------+--------------------------------------------+--------------------------------------------+--------------------------------------------
 0x6a32acc46ee04673a906d7dc8975acf9d3f49e3e | 0xdac17f958d2ee523a2206206994597c13d831ec7 | 0x6a32acc46EE04673A906d7DC8975AcF9d3F49E3E | 0xdAC17F958D2ee523a2206206994597C13D831ec7
 0x6a32acc46ee04673a906d7dc8975acf9d3f49e3e | 0xdac17f958d2ee523a2206206994597c13d831ec7 | 0x6a32acc46EE04673A906d7DC8975AcF9d3F49E3E | 0xdAC17F958D2ee523a2206206994597C13D831ec7
 0x6a32acc46ee04673a906d7dc8975acf9d3f49e3e | 0xdac17f958d2ee523a2206206994597c13d831ec7 | 0x6a32acc46EE04673A906d7DC8975AcF9d3F49E3E | 0xdAC17F958D2ee523a2206206994597C13D831ec7
 0x6a32acc46ee04673a906d7dc8975acf9d3f49e3e | 0xdac17f958d2ee523a2206206994597c13d831ec7 | 0x6a32acc46EE04673A906d7DC8975AcF9d3F49E3E | 0xdAC17F958D2ee523a2206206994597C13D831ec7
 0x6a32acc46ee04673a906d7dc8975acf9d3f49e3e | 0xdac17f958d2ee523a2206206994597c13d831ec7 | 0x6a32acc46EE04673A906d7DC8975AcF9d3F49E3E | 0xdAC17F958D2ee523a2206206994597C13D831ec7
 0x6a32acc46ee04673a906d7dc8975acf9d3f49e3e | 0xdac17f958d2ee523a2206206994597c13d831ec7 | 0x6a32acc46EE04673A906d7DC8975AcF9d3F49E3E | 0xdAC17F958D2ee523a2206206994597C13D831ec7
 0x6a32acc46ee04673a906d7dc8975acf9d3f49e3e | 0xdac17f958d2ee523a2206206994597c13d831ec7 | 0x6a32acc46EE04673A906d7DC8975AcF9d3F49E3E | 0xdAC17F958D2ee523a2206206994597C13D831ec7
```