### PR TITLE
Fix non-awaited 'self.raw_db.disconnect()' coroutine

### DIFF
--- a/jsearch/pending_syncer/services/syncer.py
+++ b/jsearch/pending_syncer/services/syncer.py
@@ -28,7 +28,7 @@ class PendingSyncerService(mode.Service):
         await self.main_db.connect()
 
     async def on_stop(self) -> None:
-        self.raw_db.disconnect()
+        await self.raw_db.disconnect()
         await self.main_db.disconnect()
 
     @mode.Service.task


### PR DESCRIPTION
`RawDB` is async-based after #373.

Source:
```
...
jsearch/utils.py::jsearch.utils.parse_range PASSED                                                                                                                                                       [ 99%]
jsearch/common/wallet_events.py::jsearch.common.wallet_events.make_event_index PASSED                                                                                                                    [100%]

=============================================================================================== warnings summary ===============================================================================================
jsearch/pending_syncer/tests/test_pending_txs.py::test_pending_tx_is_not_saved_if_there_is_none
jsearch/pending_syncer/tests/test_pending_txs.py::test_pending_tx_is_saved_to_main_db
jsearch/pending_syncer/tests/test_pending_txs.py::test_pending_tx_is_marked_as_removed
jsearch/pending_syncer/tests/test_pending_txs.py::test_pending_tx_can_be_saved_with_a_big_value
jsearch/pending_syncer/tests/test_pending_txs.py::test_pending_syncer_processes_related_txs_in_order
jsearch/pending_syncer/tests/test_pending_txs.py::test_pending_syncer_overrides_stale_data_in_db
jsearch/pending_syncer/tests/test_pending_txs.py::test_pending_syncer_does_not_override_stale_data_in_db
jsearch/pending_syncer/tests/test_pending_txs.py::test_pending_syncer_can_fetch_txs_if_none_synced_yet_and_first_one_is_far_away
  /app/jsearch/pending_syncer/services/syncer.py:31: RuntimeWarning: coroutine 'DBWrapper.disconnect' was never awaited
    self.raw_db.disconnect()

-- Docs: https://docs.pytest.org/en/latest/warnings.html

----------- coverage: platform linux, python 3.7.3-final-0 -----------
```