### PR TITLE
JSEARCH-503 Fix too long migration.

### DIFF
--- a/jsearch/common/migrations/versions/d4a2a13a03ad_update_int_to_bingint.py
+++ b/jsearch/common/migrations/versions/d4a2a13a03ad_update_int_to_bingint.py
@@ -15,31 +15,13 @@ depends_on = None
 
 # WTF: Postgres integer limit is 2,147,483,647. Soon or later we will reach this limit.
 UP_SQL = """
-ALTER TABLE accounts_state ALTER COLUMN block_number TYPE BIGINT;
-ALTER TABLE assets_summary ALTER COLUMN block_number TYPE BIGINT;
-ALTER TABLE blocks ALTER COLUMN number TYPE BIGINT;
-ALTER TABLE transactions ALTER COLUMN block_number TYPE BIGINT;
-ALTER TABLE internal_transactions ALTER COLUMN block_number TYPE BIGINT;
-ALTER TABLE logs ALTER COLUMN block_number TYPE BIGINT;
-ALTER TABLE reorgs ALTER COLUMN block_number TYPE BIGINT;
 ALTER TABLE reorgs ALTER COLUMN id TYPE BIGINT;
-ALTER TABLE token_holders ALTER COLUMN block_number TYPE BIGINT;
-ALTER TABLE token_transfers ALTER COLUMN block_number TYPE BIGINT;
-ALTER TABLE uncles ALTER COLUMN block_number TYPE BIGINT;
+ALTER TABLE token_holders ALTER COLUMN id TYPE BIGINT;
 """
 
 DOWN_SQL = """
-ALTER TABLE accounts_state ALTER COLUMN block_number TYPE INTEGER;
-ALTER TABLE assets_summary ALTER COLUMN block_number TYPE INTEGER;
-ALTER TABLE blocks ALTER COLUMN number TYPE INTEGER;
-ALTER TABLE transactions ALTER COLUMN block_number TYPE INTEGER;
-ALTER TABLE internal_transactions ALTER COLUMN block_number TYPE INTEGER;
-ALTER TABLE logs ALTER COLUMN block_number TYPE INTEGER;
-ALTER TABLE reorgs ALTER COLUMN block_number TYPE INTEGER;
 ALTER TABLE reorgs ALTER COLUMN id TYPE INTEGER;
-ALTER TABLE token_holders ALTER COLUMN block_number TYPE INTEGER;
-ALTER TABLE token_transfers ALTER COLUMN block_number TYPE INTEGER;
-ALTER TABLE uncles ALTER COLUMN block_number TYPE INTEGER;
+ALTER TABLE token_holders ALTER COLUMN id TYPE INTEGER;
 """
 
 

--- a/jsearch/syncer/main.py
+++ b/jsearch/syncer/main.py
@@ -19,7 +19,7 @@ async def wait_new_scheme():
     query = """
     SELECT column_name
     FROM information_schema.columns
-    WHERE table_name = 'blocks' AND column_name = 'number' and data_type = 'bigint';
+    WHERE table_name = 'token_holders' AND column_name = 'id' and data_type = 'bigint';
     """
     engine = await create_engine(dsn=settings.JSEARCH_MAIN_DB, maxsize=1)
     while True:


### PR DESCRIPTION
I think - i did mistake when decided to change column type for block_number. It will lead to full copy of our database. I want to improve it.