### PR TITLE
ETHBE-675

### DIFF
--- a/jsearch/common/structs.py
+++ b/jsearch/common/structs.py
@@ -17,7 +17,7 @@ class NodeStats(NamedTuple):
     is_healthy: bool
 
 
-class SyncRange(NamedTuple):
+class BlockRange(NamedTuple):
     start: int
     end: Optional[int]
 

--- a/jsearch/pending_syncer/main.py
+++ b/jsearch/pending_syncer/main.py
@@ -2,7 +2,7 @@ import click
 
 from jsearch import settings
 from jsearch.common import logs, worker, stats
-from jsearch.common.structs import SyncRange
+from jsearch.common.structs import BlockRange
 from jsearch.pending_syncer import services
 from jsearch.utils import parse_range
 
@@ -19,7 +19,7 @@ def run(log_level, no_json_formatter, sync_range):
     # didn't do it right now because this causes slight refactoring of the
     # `jsearch.syncer.manager.Manager` which causes merge conflicts.
     parsed_range = parse_range(sync_range)
-    parsed_sync_range = SyncRange(start=parsed_range[0], end=parsed_range[1])
+    parsed_sync_range = BlockRange(start=parsed_range[0], end=parsed_range[1])
 
     worker.Worker(
         services.PendingSyncerService(

--- a/jsearch/pending_syncer/services/syncer.py
+++ b/jsearch/pending_syncer/services/syncer.py
@@ -9,7 +9,7 @@ from jsearch.syncer.database_queries.pending_transactions import prepare_pending
 
 from jsearch import settings
 from jsearch.common import metrics, async_utils
-from jsearch.common.structs import SyncRange
+from jsearch.common.structs import BlockRange
 from jsearch.syncer.database import MainDB, RawDB
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ ADVISORY_LOCK_ID = -1
 
 
 class PendingSyncerService(mode.Service):
-    def __init__(self, raw_db_dsn: str, main_db_dsn: str, sync_range: SyncRange, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, raw_db_dsn: str, main_db_dsn: str, sync_range: BlockRange, *args: Any, **kwargs: Any) -> None:
         self.raw_db = RawDB(raw_db_dsn)
         self.main_db = MainDB(main_db_dsn)
         self.sync_range = sync_range

--- a/jsearch/pending_syncer/tests/test_pending_txs.py
+++ b/jsearch/pending_syncer/tests/test_pending_txs.py
@@ -6,7 +6,7 @@ from psycopg2._json import Json
 from sqlalchemy import select
 from sqlalchemy.engine import Engine
 
-from jsearch.common.structs import SyncRange
+from jsearch.common.structs import BlockRange
 from jsearch.common.tables import pending_transactions_t
 from jsearch.pending_syncer.services import PendingSyncerService
 
@@ -71,7 +71,7 @@ async def pending_syncer_service(
         raw_db_dsn=raw_db_dsn,
         main_db_dsn=db_dsn,
         loop=event_loop,
-        sync_range=SyncRange(0, None)
+        sync_range=BlockRange(0, None)
     )
 
     await service.on_start()

--- a/jsearch/syncer/manager.py
+++ b/jsearch/syncer/manager.py
@@ -3,10 +3,10 @@ import logging
 
 import backoff
 import time
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional
 
 from jsearch import settings
-from jsearch.common.structs import SyncRange
+from jsearch.common.structs import BlockRange
 from jsearch.syncer.database import MainDB, RawDB
 from jsearch.syncer.processor import SyncProcessor
 from jsearch.syncer.state import SyncerState
@@ -101,7 +101,7 @@ class Manager:
             service,
             main_db,
             raw_db,
-            sync_range,
+            sync_range: BlockRange,
             state: Optional[SyncerState] = False,
             resync: bool = False
     ):
@@ -192,7 +192,7 @@ class Manager:
 
     async def resync_loop(self):
         logger.info("Entering ReSync Loop")
-        for block_number in range(self.sync_range[1], self.sync_range[0], -1):
+        for block_number in range(self.sync_range.end, self.sync_range.start, -1):
             if not self._running:
                 logger.info("Leave ReSync Loop")
                 break
@@ -248,22 +248,37 @@ class Manager:
 
     @backoff.on_exception(backoff.expo, max_tries=settings.SYNCER_BACKOFF_MAX_TRIES, exception=Exception)
     async def get_and_process_chain_event(self):
-        start, end = self.sync_range
-        start, end = await get_range_and_check_holes(self.main_db, start, end, self.state)
-        block_range = (start, end)
+        block_range = await get_range_and_check_holes(self.main_db, self.sync_range, self.state)
 
+        logger.info("Try to find new event", extra={"range": block_range})
         last_event = await self.main_db.get_last_chain_event(block_range, self.node_id)
         if last_event is None:
             next_event = await self.raw_db.get_first_chain_event_for_block_range(block_range, self.node_id)
         else:
             next_event = await self.raw_db.get_next_chain_event(block_range, last_event['id'], self.node_id)
 
-        if self.sync_range[1] and next_event is None:
+        if self.state.hole and next_event is None:
+            self.state.checked_on_holes = self.state.hole
+            self.state.last_processed_block = self.state.hole.end
+            self.state.hole = None
+            logger.error(
+                "No events in the gap",
+                extra={"range": self.state.checked_on_holes}
+            )
+            return
+
+        there_is_no_gap_in_middle = not self.state.hole or block_range.end and self.state.hole.end >= block_range.end
+        is_sync_complete = (
+                there_is_no_gap_in_middle
+                and self.sync_range.end
+                and next_event is None
+        )
+        if is_sync_complete:
             logger.info(
                 'Sync range complete',
                 extra={
-                    'from': self.sync_range[0],
-                    'to': self.sync_range[1]
+                    'from': self.sync_range.start,
+                    'to': self.sync_range.end
                 }
             )
             await asyncio.sleep(10)
@@ -277,15 +292,14 @@ class Manager:
         await self.process_chain_event(next_event)
 
     async def try_lock_range(self):
-        return await self.main_db.try_advisory_lock(self.sync_range[0], self.sync_range[1])
+        return await self.main_db.try_advisory_lock(self.sync_range.start, self.sync_range.end)
 
 
 async def get_range_and_check_holes(
         main_db: MainDB,
-        start: int,
-        end: Optional[int],
+        sync_range: BlockRange,
         state: SyncerState
-) -> Tuple[int, Optional[int]]:
+) -> BlockRange:
     """
     Get range until
     a                     b
@@ -321,19 +335,24 @@ async def get_range_and_check_holes(
           - hole
           - checked_on_holes
     """
-    if end is None:
-        return start, end
+    end = sync_range.end
+    start = sync_range.start
+
+    if sync_range.end is None:
+        return BlockRange(start, end)
 
     if state.hole and state.last_processed_block < state.hole.end:
         end = state.hole.end
-    elif state.checked_on_holes and state.last_check_blocks <= state.checked_on_holes.end:
+    elif state.checked_on_holes and state.last_processed_block < state.checked_on_holes.end:
         end = state.checked_on_holes.end
     else:
-        hole_right_border = await main_db.check_on_holes(start, end)
+        hole_left_border = (state.checked_on_holes and state.checked_on_holes.end + 1) or start
+        hole_right_border = await main_db.check_on_holes(hole_left_border, end)
         if hole_right_border:
-            state.hole = SyncRange(start, hole_right_border)
+            state.hole = BlockRange(start, hole_right_border)
             end = hole_right_border
         else:
             state.hole = None
-            state.checked_on_holes = SyncRange(start, end)
-    return start, end
+            state.checked_on_holes = BlockRange(start, end)
+
+    return BlockRange(start, end)

--- a/jsearch/syncer/services/scaler.py
+++ b/jsearch/syncer/services/scaler.py
@@ -17,7 +17,7 @@ from webargs.aiohttpparser import use_kwargs
 from jsearch import settings
 from jsearch.api.middlewares import cors_middleware
 from jsearch.common import services
-from jsearch.common.structs import SyncRange
+from jsearch.common.structs import BlockRange
 from jsearch.syncer.pool import WorkersPool
 from jsearch.syncer.utils import get_last_block
 from jsearch.utils import parse_range
@@ -60,7 +60,7 @@ class SyncRangeField(fields.String):
     def _deserialize(self, value, attr, data):
         value = super(SyncRangeField, self)._deserialize(value, attr, data)
         if value:
-            return SyncRange(*parse_range(value))
+            return BlockRange(*parse_range(value))
 
 
 class ScaleSchema(Schema):
@@ -73,7 +73,7 @@ class ScaleSchema(Schema):
 )
 @request_schema(ScaleSchema(strict=True))
 @use_kwargs(ScaleSchema())
-async def post_scale(request: web.Request, sync_range: SyncRange, workers: int) -> web.Response:
+async def post_scale(request: web.Request, sync_range: BlockRange, workers: int) -> web.Response:
     pool: WorkersPool = request.app['pool']
 
     last_block = get_last_block()

--- a/jsearch/syncer/services/syncer.py
+++ b/jsearch/syncer/services/syncer.py
@@ -1,9 +1,10 @@
 import logging
 
 import mode
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from jsearch import settings
+from jsearch.common.structs import BlockRange
 from jsearch.syncer.database import MainDB, RawDB
 from jsearch.syncer.manager import Manager
 from jsearch.syncer.state import SyncerState
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 class SyncerService(mode.Service):
     def __init__(self,
                  state: SyncerState,
-                 sync_range: Tuple[int, int],
+                 sync_range: BlockRange,
                  resync: Optional[bool] = False,
                  *args: Any,
                  **kwargs: Any) -> None:

--- a/jsearch/syncer/state.py
+++ b/jsearch/syncer/state.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 from typing import Optional
 
-from jsearch.common.structs import SyncRange
+from jsearch.common.structs import BlockRange
 
 
 @dataclass
@@ -18,8 +18,8 @@ class SyncerState:
     last_check_blocks: int = 0
     new_check_blocks: int = 0
 
-    hole: Optional[SyncRange] = None
-    checked_on_holes: Optional[SyncRange] = None
+    hole: Optional[BlockRange] = None
+    checked_on_holes: Optional[BlockRange] = None
 
     CHECK_TIMEOUT: int = 60
 

--- a/jsearch/syncer/tests/test_manager.py
+++ b/jsearch/syncer/tests/test_manager.py
@@ -41,7 +41,7 @@ This is history data.
 
 import pytest
 
-from jsearch.common.structs import SyncRange
+from jsearch.common.structs import BlockRange
 from jsearch.common.tables import assets_summary_t
 from jsearch.syncer.database import RawDB, MainDB
 from jsearch.syncer.manager import Manager
@@ -57,7 +57,7 @@ def mock_getting_last_block_from_row_db(mocker):
 
 async def call_system_under_test(db_dsn: MainDB, raw_db_dsn: str, start: int, end: int) -> None:
     async with MainDB(db_dsn) as main_db, RawDB(raw_db_dsn) as raw_db:
-        manager = Manager(None, main_db, raw_db, sync_range=SyncRange(start=start, end=end))
+        manager = Manager(None, main_db, raw_db, sync_range=BlockRange(start=start, end=end))
         for i in range(0, 10):
             await manager.get_and_process_chain_event()
 


### PR DESCRIPTION
Fix case when there is a gap in the middle of synced range.
And there are no events in raw db for this gap.

Gap example:
RAW_DB:
```
0 1 2 3 4 5 6 7 8 9 
x x . . . x x x x x
```

MAIN_DB
```
0 1 2 3 4 5 6 7 8 9
x x . . . x x . . x
```

In this case syncer in previous implementation have been stopped with passed sync range is completed check. And blocks 7 and 8 was not synced.
  