### PR TITLE
Increase queries to find a gaps in block range.

### DIFF
--- a/jsearch/syncer/database/main.py
+++ b/jsearch/syncer/database/main.py
@@ -159,46 +159,48 @@ class MainDB(DBWrapper):
             row = await res.fetchone()
             return row is not None
 
-    @async_timeit(name='Query to find gaps')
-    async def check_on_holes(self, start: int, end: int) -> Optional[int]:
-        """
-        We use next technique to found gaps:
-
-        We get a range a ... z,
-            and do left join with self,
-            after - filter by left side.
-
-          |a|       |b| ( a - 1 )
-          |b| join  |c| ( b - 1 )
-          |c|       |d| ( c - 1 )
-          |d|       | |
-          | |       | |
-          | |       | |
-
-        We need a minimal number to find gap.
-        In example up there it is `d`.
-
-        """
+    async def get_set_left_border(self, start: int, end: int) -> Optional[int]:
         query = """
-        SELECT
-            blocks.number - 1 as number
-        FROM blocks
-        LEFT JOIN blocks as l ON l.number = blocks.number - 1
-        WHERE blocks.number >= %s and blocks.number <= %s
-            AND blocks.is_forked = False
-            AND l.number IS null
-        ORDER BY blocks.number LIMIT 1;
+            select min(number) as edge
+            from blocks
+            where is_forked = false and number >= %s and number <= %s;
         """
-        result = await self.fetch_one(query, start + 1, end)
+        result = await self.fetch_one(query, start, end)
+        if result:
+            return result.edge
+
+    async def get_gap_right_border(self, start: int, end: int) -> Optional[int]:
+        query = """
+        select next_number - 1 as gap_end
+        from (
+          select number, lead(number) over (order by number asc) as next_number
+          from blocks
+          where is_forked = false and blocks.number >= %s and blocks.number < %s
+        ) numbers
+        where number + 1 <> next_number limit 1;
+        """
+        result = await self.fetch_one(query, start, end + 1)
         if result:
             logger.info(
                 'Gap was founded',
                 extra={
-                    'gap': BlockRange(start, result.number),
+                    'gap': BlockRange(start, result.gap_end),
                     'range': BlockRange(start, end)
                 }
             )
-            return result.number
+            return result.gap_end
+
+    @async_timeit(name='Query to find gaps')
+    async def check_on_holes(self, start: int, end: int) -> Optional[int]:
+        records_right_border = await self.get_set_left_border(start, end)
+
+        if records_right_border and records_right_border != start:
+            gap_right_border = records_right_border - 1
+            return gap_right_border if gap_right_border > start else start
+
+        gap_right_border = await self.get_gap_right_border(start, end)
+        if gap_right_border:
+            return gap_right_border
 
     @async_timeit('[MAIN DB] Get last chain event')
     async def get_last_chain_event(self, sync_range: BlockRange, node_id: str) -> None:


### PR DESCRIPTION
Previous query subject to changing of plan:
```
postgres=#         explain SELECT
            blocks.number - 1 as number
        FROM blocks
        LEFT JOIN blocks as l ON l.number = blocks.number - 1
        WHERE blocks.number BETWEEN 2000000 AND 2500000
            AND blocks.is_forked = False
            AND l.number IS null
        ORDER BY blocks.number LIMIT 1;
```
```
 Limit  (cost=0.43..110832.58 rows=1 width=8)
   ->  Nested Loop Anti Join  (cost=0.43..14227744481.23 rows=128372 width=8)
         Join Filter: (l.number = (blocks.number - 1))
         ->  Index Only Scan using ix_blocks_timestamp on blocks  (cost=0.43..157906.21 rows=256744 width=4)
               Index Cond: ((number >= 2000000) AND (number <= 2500000))
         ->  Materialize  (cost=0.00..407592.16 rows=3299277 width=4)
               ->  Seq Scan on blocks l  (cost=0.00..378207.77 rows=3299277 width=4)
(7 rows)

postgres=#
```
***Materialize*** is very very bad for perfomance.
New query will be more fast and simply.
```postgres=# 
explain select number as gap_start, next_number - 1 as gap_end
from (
  select number, lead(number) over (order by number) as next_number
  from blocks
  where is_forked = false and blocks.number >= 2000000 and blocks.number < 2500000
) numbers
where number + 1 <> next_number;
                                                QUERY PLAN
----------------------------------------------------------------------------------------------------------
 Subquery Scan on numbers  (cost=0.43..9097.38 rows=16660 width=8)
   Filter: ((numbers.number + 1) <> numbers.next_number)
   ->  WindowAgg  (cost=0.43..8804.57 rows=16744 width=8)
         ->  Index Only Scan using ix_blocks_timestamp on blocks  (cost=0.43..8553.41 rows=16744 width=4)
               Index Cond: ((number >= 2000000) AND (number < 2500000))
(5 rows)

postgres=#```