### PR TITLE
ETHBE-674: Return 'BlockchainTip' instead of 'BlockchainTipAsDict'

### DIFF
--- a/jsearch/api/blockchain_tip.py
+++ b/jsearch/api/blockchain_tip.py
@@ -4,7 +4,6 @@ from jsearch.api.error_code import ErrorCode
 from jsearch.api.helpers import ApiError
 from jsearch.api.storage import Storage
 from jsearch.api.structs import BlockchainTip, BlockInfo
-from jsearch.typing import BlockchainTipAsDict
 
 T = TypeVar('T')
 
@@ -15,7 +14,7 @@ async def maybe_apply_tip(
         data: T,
         last_affected_block: Optional[int],
         empty: T,
-) -> Tuple[T, Optional[BlockchainTipAsDict]]:
+) -> Tuple[T, Optional[BlockchainTip]]:
     if tip_hash is None:
         # WTF: `BlockchainTip` is not a required query param and can be omitted
         # by clients. If it was omitted, do not apply tip.
@@ -24,7 +23,7 @@ async def maybe_apply_tip(
     tip = await get_tip_or_raise_api_error(storage, tip_hash)
     tip_is_stale = is_tip_stale(tip, last_affected_block)
 
-    return empty if tip_is_stale else data, tip.to_dict()
+    return empty if tip_is_stale else data, tip
 
 
 async def get_tip_or_raise_api_error(

--- a/jsearch/api/handlers/accounts.py
+++ b/jsearch/api/handlers/accounts.py
@@ -55,10 +55,10 @@ async def get_accounts_balances(request):
         ])
 
     balances, last_affected_block = await storage.get_accounts_balances(addresses)
-    balances, tip_meta = await maybe_apply_tip(storage, tip_hash, balances, last_affected_block, empty=[])
+    balances, tip = await maybe_apply_tip(storage, tip_hash, balances, last_affected_block, empty=[])
     balances = [b.to_dict() for b in balances]
 
-    return api_success(balances, meta=tip_meta)
+    return api_success(balances, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -76,10 +76,10 @@ async def get_account(request):
     if account is None:
         return api_error_response_404()
 
-    account, tip_meta = await maybe_apply_tip(storage, tip_hash, account, last_affected_block, empty=None)
+    account, tip = await maybe_apply_tip(storage, tip_hash, account, last_affected_block, empty=None)
     account = {} if account is None else account.to_dict()
 
-    return api_success(account, meta=tip_meta)
+    return api_success(account, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -109,12 +109,12 @@ async def get_account_transactions(
         tx_index=transaction_index
     )
 
-    txs, tip_meta = await maybe_apply_tip(storage, tip_hash, txs, last_affected_block, empty=[])
+    txs, tip = await maybe_apply_tip(storage, tip_hash, txs, last_affected_block, empty=[])
 
     url = request.app.router['accounts_txs'].url_for(address=address)
     page = get_page(url=url, items=txs, limit=limit, ordering=order)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -144,12 +144,12 @@ async def get_account_internal_txs(
         parent_tx_index=parent_transaction_index,
         tx_index=transaction_index
     )
-    txs, tip_meta = await maybe_apply_tip(storage, tip_hash, txs, last_affected_block, empty=[])
+    txs, tip = await maybe_apply_tip(storage, tip_hash, txs, last_affected_block, empty=[])
 
     url = request.app.router['accounts_internal_txs'].url_for(address=address)
     page = get_page(url=url, items=txs, limit=limit, ordering=order, mapping=AccountsInternalTxsSchema.mapping)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -212,12 +212,12 @@ async def get_account_logs(
         transaction_index=transaction_index,
         log_index=log_index,
     )
-    logs, tip_meta = await maybe_apply_tip(storage, tip_hash, logs, last_affected_block, empty=[])
+    logs, tip = await maybe_apply_tip(storage, tip_hash, logs, last_affected_block, empty=[])
 
     url = request.app.router['accounts_logs'].url_for(address=address)
     page = get_page(url=url, items=logs, limit=limit, ordering=order)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -245,12 +245,12 @@ async def get_account_mined_blocks(
         block_number,
     )
 
-    blocks, tip_meta = await maybe_apply_tip(storage, tip_hash, blocks, last_affected_block, empty=[])
+    blocks, tip = await maybe_apply_tip(storage, tip_hash, blocks, last_affected_block, empty=[])
 
     url = request.app.router['accounts_mined_blocks'].url_for(address=address)
     page = get_page(url=url, items=blocks, limit=limit, ordering=order, mapping=AccountMinedBlocksSchema.mapping)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -279,12 +279,12 @@ async def get_account_mined_uncles(
         address=address,
     )
 
-    uncles, tip_meta = await maybe_apply_tip(storage, tip_hash, uncles, last_affected_block, empty=[])
+    uncles, tip = await maybe_apply_tip(storage, tip_hash, uncles, last_affected_block, empty=[])
 
     url = request.app.router['accounts_mined_uncles'].url_for(address=address)
     page = get_page(url=url, items=uncles, limit=limit, ordering=order, mapping=AccountUncleSchema.mapping)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -315,12 +315,12 @@ async def get_account_token_transfers(
         transaction_index=transaction_index,
         log_index=log_index
     )
-    transfers, tip_meta = await maybe_apply_tip(storage, tip_hash, transfers, last_affected_block, empty=[])
+    transfers, tip = await maybe_apply_tip(storage, tip_hash, transfers, last_affected_block, empty=[])
 
     url = request.app.router['account_transfers'].url_for(address=address)
     page = get_page(url=url, items=transfers, limit=limit, ordering=order)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -338,10 +338,10 @@ async def get_account_token_balance(request):
     if holder is None:
         return api_error_response_404()
 
-    holder, tip_meta = await maybe_apply_tip(storage, tip_hash, holder, last_affected_block, empty=None)
+    holder, tip = await maybe_apply_tip(storage, tip_hash, holder, last_affected_block, empty=None)
     holder = {} if holder is None else holder.to_dict()
 
-    return api_success(holder, meta=tip_meta)
+    return api_success(holder, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -361,8 +361,8 @@ async def get_account_token_balances_multi(request):
         ])
 
     balances, last_affected_block = await storage.get_account_tokens_balances(account_address, tokens_addresses)
-    balances, tip_meta = await maybe_apply_tip(storage, tip_hash, balances, last_affected_block, empty=[])
-    return api_success([b.to_dict() for b in balances], meta=tip_meta)
+    balances, tip = await maybe_apply_tip(storage, tip_hash, balances, last_affected_block, empty=[])
+    return api_success([b.to_dict() for b in balances], meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -405,7 +405,7 @@ async def get_account_eth_transfers(request,
                                                                              event_index=event_index,
                                                                              order=order,
                                                                              limit=limit + 1)
-    transfers, tip_meta = await maybe_apply_tip(storage, tip_hash, transfers, last_affected_block, empty=[])
+    transfers, tip = await maybe_apply_tip(storage, tip_hash, transfers, last_affected_block, empty=[])
     url = request.app.router['accounts_eth_transfers'].url_for(address=address)
     page = get_page(url=url, items=transfers, key_set_fields=get_key_set_fields(order.scheme), limit=limit,
                     ordering=order, mapping=EthTransfersListSchema.mapping)
@@ -415,4 +415,4 @@ async def get_account_eth_transfers(request,
         del d['block_number']
         del d['event_index']
         data.append(d)
-    return api_success(data=data, page=page, meta=tip_meta)
+    return api_success(data=data, page=page, meta=tip and tip.to_dict())

--- a/jsearch/api/handlers/blocks.py
+++ b/jsearch/api/handlers/blocks.py
@@ -39,12 +39,12 @@ async def get_blocks(
         order=order,
     )
 
-    blocks, tip_meta = await maybe_apply_tip(storage, tip_hash, blocks, last_affected_block, empty=[])
+    blocks, tip = await maybe_apply_tip(storage, tip_hash, blocks, last_affected_block, empty=[])
 
     url = request.app.router['blocks'].url_for()
     page = get_page(url=url, items=blocks, limit=limit, ordering=order, mapping=BlockListSchema.mapping)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, progress=progress, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, progress=progress, meta=tip and tip.to_dict())
 
 
 async def get_block(request):

--- a/jsearch/api/handlers/tokens.py
+++ b/jsearch/api/handlers/tokens.py
@@ -42,12 +42,12 @@ async def get_token_transfers(
         transaction_index=transaction_index,
         log_index=log_index
     )
-    transfers, tip_meta = await maybe_apply_tip(storage, tip_hash, transfers, last_affected_block, empty=[])
+    transfers, tip = await maybe_apply_tip(storage, tip_hash, transfers, last_affected_block, empty=[])
 
     url = request.app.router['token_transfers'].url_for(address=address)
     page = get_page(url=url, items=transfers, limit=limit, ordering=order)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())
 
 
 @ApiError.catch
@@ -72,9 +72,9 @@ async def get_token_holders(
         _id=_id
     )
 
-    holders, tip_meta = await maybe_apply_tip(storage, tip_hash, holders, last_affected_block, empty=[])
+    holders, tip = await maybe_apply_tip(storage, tip_hash, holders, last_affected_block, empty=[])
 
     url = request.app.router['token_holders'].url_for(address=address)
     page = get_page(url=url, items=holders, limit=limit, ordering=order, decimals_to_ints=True)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())

--- a/jsearch/api/handlers/uncles.py
+++ b/jsearch/api/handlers/uncles.py
@@ -40,12 +40,12 @@ async def get_uncles(
         order=order,
     )
 
-    uncles, tip_meta = await maybe_apply_tip(storage, tip_hash, uncles, last_affected_block, empty=[])
+    uncles, tip = await maybe_apply_tip(storage, tip_hash, uncles, last_affected_block, empty=[])
 
     url = request.app.router['uncles'].url_for()
     page = get_page(url=url, items=uncles, limit=limit, ordering=order, mapping=UncleListSchema.mapping)
 
-    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip_meta)
+    return api_success(data=[x.to_dict() for x in page.items], page=page, meta=tip and tip.to_dict())
 
 
 async def get_uncle(request):

--- a/jsearch/api/handlers/wallets.py
+++ b/jsearch/api/handlers/wallets.py
@@ -70,7 +70,7 @@ async def get_wallet_events(
         limit=limit + 1
     )
 
-    data, tip_meta = await maybe_apply_tip(storage, tip_hash, events, last_affected_block, empty=[])
+    data, tip = await maybe_apply_tip(storage, tip_hash, events, last_affected_block, empty=[])
 
     url = request.app.router['wallet_events'].url_for()
     page = get_page(
@@ -99,7 +99,7 @@ async def get_wallet_events(
         },
         page=page,
         progress=progress,
-        meta=tip_meta
+        meta=tip and tip.to_dict()
     )
 
 
@@ -133,5 +133,5 @@ async def get_assets_summary(request):
     else:
         summary = []
         last_affected_block = None
-    data, tip_meta = await maybe_apply_tip(storage, tip_hash, summary, last_affected_block, empty=[])
-    return api_success([item.to_dict() for item in data], meta=tip_meta)
+    data, tip = await maybe_apply_tip(storage, tip_hash, summary, last_affected_block, empty=[])
+    return api_success([item.to_dict() for item in data], meta=tip and tip.to_dict())


### PR DESCRIPTION
This PR updates `maybe_apply_tip` to return raw `BlockchainTip` instead of it's `dict` representation.

This allows to validate tip's `last_number` later down the road for data integrity validation.