### PR TITLE
Fix gap searching algoritm.

### DIFF
--- a/jsearch/syncer/database/main.py
+++ b/jsearch/syncer/database/main.py
@@ -181,7 +181,7 @@ class MainDB(DBWrapper):
         from (
           select number, lead(number) over (order by number asc) as next_number
           from blocks
-          where is_forked = false and blocks.number >= %s and blocks.number < %s
+          where is_forked = false and blocks.number >= %s and blocks.number <= %s
         ) numbers
         where number + 1 <> next_number limit 1;
         """

--- a/jsearch/syncer/tests/test_syncer_ranges.py
+++ b/jsearch/syncer/tests/test_syncer_ranges.py
@@ -186,6 +186,11 @@ class FindHoleCase(NamedTuple):
             ),
             FindHoleCase(
                 sync_range=BlockRange(10, 20),
+                synced_ranges=[BlockRange(10, 12), BlockRange(21, 21)],
+                gap=BlockRange(12, 20)
+            ),
+            FindHoleCase(
+                sync_range=BlockRange(10, 20),
                 synced_ranges=[BlockRange(12, 14), BlockRange(16, 18)],
                 gap=BlockRange(10, 11)
             ),
@@ -199,11 +204,15 @@ class FindHoleCase(NamedTuple):
 async def test_find_holes(
         main_db,
         sync_block_range,
+        sync_block,
         case
 ):
     # given
     for range_start, range_end in case.synced_ranges:
-        sync_block_range(range_start, range_end)
+        if range_start == range_end:
+            sync_block(range_start)
+        else:
+            sync_block_range(range_start, range_end)
 
     # then
     gap = await main_db.check_on_holes(case.sync_range.start, case.sync_range.end)


### PR DESCRIPTION
There is a case then we have a next sequence:
```
|a| | |g| | |b|b+1|
|x|x|x| | | | |x  |
```
If we set syncer range from a to b - we won't found
the gap from g to b.

The main reason is bug in sql query to find gaps right border.