### PR TITLE
ETHBE-688: Fix incomplete 'package_data'

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
 include jsearch/version.txt
+include jsearch/data_checker/proxy.list
+
+recursive-include jsearch/api/swagger *

--- a/setup.py
+++ b/setup.py
@@ -11,18 +11,10 @@ setup(
         exclude=('*.tests.*',),
         include=('jsearch', 'jsearch.*',)
     ),
-    data_files=[
-        (
-            '',
-            [
-                'jsearch/data_checker/proxy.list'
-            ],
-        )
-    ],
+    include_package_data=True,
     zip_safe=False,
     platforms='any',
     install_requires=[],
-    include_package_data=True,
     entry_points={
         'console_scripts': [
             'jsearch = jsearch.cli:cli',


### PR DESCRIPTION
Jsearch Backend API is run as an `entry_point` from `setup.py` now and, therefore, requires static `package_data` such as Swagger configuration.

These files have been added to `MANIFEST.in`.