### PR TITLE
ETHBE-720: Add 'release.md' PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,11 @@
+Please check if the PR fulfills these requirements
+
+- [ ] Version inside `version.txt` complies to the release version
+
+**Features**
+
+* ...
+
+**Fixes**
+
+* ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jsearch backend services
+# Jsearch backend services  [![Make release PR](https://img.shields.io/badge/make_release_PR-blue)](https://github.com/jibrelnetwork/jsearch-backend/compare/master...develop?template=release.md&title=Release+vX.Y.Z)
 
 This is the core of Jsearch. 
 


### PR DESCRIPTION
At the moment, GitHub is lacking UI for choosing a PR template. The only way to select PR template is to use query parameter `template`, so a hacky `README.md` button with correct URL has been added.

All new release PRs can be opened via this button.
