### PR TITLE
Fix 'paging' section API mismatch

### DIFF
--- a/jsearch/api/swagger/jsearch-v1.swagger.yaml
+++ b/jsearch/api/swagger/jsearch-v1.swagger.yaml
@@ -829,8 +829,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/Transaction'
-              paging:
-                $ref: '#/definitions/paging'
         400:
           description: bad input parameter
           schema:
@@ -865,8 +863,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/InternalTransaction'
-              paging:
-                $ref: '#/definitions/paging'
         400:
           description: bad input parameter
           schema:


### PR DESCRIPTION
This PR removes `paging` section from these endpoints:
* `/v1/blocks/{tag}/transactions`
* `/v1/blocks/{tag}/internal_transactions`

These endpoints do not implement pagination.
