### PR TITLE
ETHBE-756: Fix performance issue with wallet events

### DIFF
--- a/jsearch/api/database_queries/blocks.py
+++ b/jsearch/api/database_queries/blocks.py
@@ -149,7 +149,10 @@ def get_block_number_by_timestamp_query(timestamp: int, order_direction: OrderDi
     operator_or_equal = DIRECTIONS_OPERATOR_OR_EQUAL_MAPS[order_direction]
 
     return select([blocks_t.c.number, blocks_t.c.hash, blocks_t.c.timestamp]).where(
-        operator_or_equal(blocks_t.c.timestamp, timestamp)
+        and_(
+            operator_or_equal(blocks_t.c.timestamp, timestamp),
+            blocks_t.c.is_forked == false(),
+        )
     ).order_by(direction_func(blocks_t.c.timestamp))
 
 

--- a/jsearch/api/tests/test_storage_get_block_by_timestamp.py
+++ b/jsearch/api/tests/test_storage_get_block_by_timestamp.py
@@ -1,0 +1,68 @@
+from typing import NamedTuple
+
+import pytest
+
+from jsearch.api.storage import Storage
+from jsearch.tests.plugins.databases.factories.blocks import BlockFactory
+
+
+class ClosestBlockCase(NamedTuple):
+    timestamp_delta: int
+    order_direction: str
+    is_block_expected: bool
+
+
+@pytest.mark.parametrize(
+    'timestamp_delta, order_direction, is_block_expected',
+    (
+        ClosestBlockCase(timestamp_delta=2, order_direction='desc', is_block_expected=True),
+        ClosestBlockCase(timestamp_delta=2, order_direction='asc', is_block_expected=False),
+        ClosestBlockCase(timestamp_delta=-2, order_direction='desc', is_block_expected=False),
+        ClosestBlockCase(timestamp_delta=-2, order_direction='asc', is_block_expected=True),
+        ClosestBlockCase(timestamp_delta=0, order_direction='desc', is_block_expected=True),
+        ClosestBlockCase(timestamp_delta=0, order_direction='asc', is_block_expected=True),
+    ),
+    ids=[
+        'timestamp is bigger + descending = block is returned',
+        'timestamp is bigger + ascending = block is not returned',
+        'timestamp is smaller + descending = block is not returned',
+        'timestamp is smaller + ascending = block is returned',
+        'timestamp is exact + ascending = block is returned',
+        'timestamp is exact + descending = block is returned',
+    ]
+)
+async def test_get_block_by_timestamp_selects_closest_block(
+        block_factory: BlockFactory,
+        storage: Storage,
+        timestamp_delta: int,
+        order_direction: str,
+        is_block_expected: bool,
+) -> None:
+    block = block_factory.create()
+    block_info = await storage.get_block_by_timestamp(
+        timestamp=block.timestamp + timestamp_delta,
+        order_direction=order_direction,
+    )
+
+    assert bool(block_info) is is_block_expected
+
+
+@pytest.mark.parametrize('order_direction', ('desc', 'asc'))
+async def test_get_block_by_timestamp_does_not_return_anything_if_theres_no_blocks(
+        block_factory: BlockFactory,
+        storage: Storage,
+        order_direction: str,
+) -> None:
+    assert await storage.get_block_by_timestamp(1575289040, order_direction) is None
+
+
+@pytest.mark.parametrize('order_direction', ('desc', 'asc'))
+async def test_get_block_by_timestamp_does_not_return_block_from_fork(
+        block_factory: BlockFactory,
+        storage: Storage,
+        order_direction: str,
+) -> None:
+    block = block_factory.create(is_forked=True)
+    block_info = await storage.get_block_by_timestamp(timestamp=block.timestamp, order_direction=order_direction)
+
+    assert block_info is None


### PR DESCRIPTION
This PR fixes lookup at `Storage.get_block_by_timestamp`. The previous query did not use the `ix_blocks_timestamp` because it didn't have `is_forked = false` criteria.