### PR TITLE
ETHBE-756: Fix unlimited 'get_block_number_by_timestamp_query'

### DIFF
--- a/jsearch/api/database_queries/blocks.py
+++ b/jsearch/api/database_queries/blocks.py
@@ -153,7 +153,7 @@ def get_block_number_by_timestamp_query(timestamp: int, order_direction: OrderDi
             operator_or_equal(blocks_t.c.timestamp, timestamp),
             blocks_t.c.is_forked == false(),
         )
-    ).order_by(direction_func(blocks_t.c.timestamp))
+    ).order_by(direction_func(blocks_t.c.timestamp)).limit(1)
 
 
 def generate_blocks_query(

--- a/jsearch/api/tests/test_storage_get_block_by_timestamp.py
+++ b/jsearch/api/tests/test_storage_get_block_by_timestamp.py
@@ -2,6 +2,7 @@ from typing import NamedTuple
 
 import pytest
 
+from jsearch.api.database_queries.blocks import get_block_number_by_timestamp_query
 from jsearch.api.storage import Storage
 from jsearch.tests.plugins.databases.factories.blocks import BlockFactory
 
@@ -66,3 +67,13 @@ async def test_get_block_by_timestamp_does_not_return_block_from_fork(
     block_info = await storage.get_block_by_timestamp(timestamp=block.timestamp, order_direction=order_direction)
 
     assert block_info is None
+
+
+@pytest.mark.parametrize('order_direction', ('desc', 'asc'))
+async def test_get_block_number_by_timestamp_query_limits_query_by_one(
+        block_factory: BlockFactory,
+        storage: Storage,
+        order_direction: str,
+) -> None:
+    query = get_block_number_by_timestamp_query(1575289040, order_direction)
+    assert query._limit == 1


### PR DESCRIPTION
This PR fixes absence of the limit for `get_block_number_by_timestamp_query`. Right now, this causes full table scan and performs poorly:
```
jsearch_main=# EXPLAIN SELECT blocks.number, blocks.hash, blocks.timestamp FROM blocks WHERE blocks.timestamp <= 1574683385 AND blocks.is_forked = false ORDER BY blocks.timestamp DESC;
                                      QUERY PLAN
---------------------------------------------------------------------------------------
 Gather Merge  (cost=1706084.77..2572325.71 rows=7424404 width=75)
   Workers Planned: 2
   ->  Sort  (cost=1705084.74..1714365.25 rows=3712202 width=75)
         Sort Key: "timestamp" DESC
         ->  Parallel Seq Scan on blocks  (cost=0.00..970116.16 rows=3712202 width=75)
               Filter: ((NOT is_forked) AND ("timestamp" <= 1574683385))
(6 rows)
```