### PR TITLE
Fix not starting 'PendingSyncer's API service

### DIFF
--- a/jsearch/pending_syncer/main.py
+++ b/jsearch/pending_syncer/main.py
@@ -27,7 +27,6 @@ def run(log_level, no_json_formatter, sync_range):
             main_db_dsn=settings.JSEARCH_MAIN_DB,
             sync_range=parsed_sync_range,
         ),
-        services.ApiService(),
     ).execute_from_commandline()
 
 

--- a/jsearch/pending_syncer/services/syncer.py
+++ b/jsearch/pending_syncer/services/syncer.py
@@ -11,6 +11,7 @@ from jsearch import settings
 from jsearch.common.prom_metrics import METRIC_SYNCER_PENDING_TXS_BATCH_SYNC_SPEED, METRIC_SYNCER_PENDING_LAG_RAW_DB
 from jsearch.common.structs import BlockRange
 from jsearch.common.utils import timeit
+from jsearch.pending_syncer.services import ApiService
 from jsearch.pending_syncer.utils.processing import prepare_pending_txs
 from jsearch.syncer.database import MainDB, RawDB
 
@@ -23,11 +24,16 @@ class PendingSyncerService(mode.Service):
         self.main_db = MainDB(main_db_dsn)
         self.sync_range = sync_range
 
+        self.api = ApiService()
+
         super().__init__(**kwargs)
 
     async def on_start(self) -> None:
         await self.raw_db.connect()
         await self.main_db.connect()
+
+    def on_init_dependencies(self) -> List[mode.Service]:
+        return [self.api]
 
     async def on_stop(self) -> None:
         await self.raw_db.disconnect()


### PR DESCRIPTION
This PR fixes non-starting API service of the `PendingSyncer` caused by #559. Due to this error, there're no Metrics & Healthcheck available:

<img width="802" alt="Screen Shot 2019-12-05 at 12 23 21 PM" src="https://user-images.githubusercontent.com/8746283/70221804-08c75c80-175a-11ea-99cb-6a2c57be12dc.png">
