### PR TITLE
ETHBE-765: Update the spec to match implementation

### DIFF
--- a/jsearch/api/swagger/jsearch-v1.swagger.yaml
+++ b/jsearch/api/swagger/jsearch-v1.swagger.yaml
@@ -1264,6 +1264,12 @@ paths:
                     type: string
                     format: dec
                     example: "10000000000000"
+        '400':
+          description: Input parameter has failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /v1/proxy/transaction_count:
     post:
       tags:
@@ -1299,6 +1305,12 @@ paths:
                     type: string
                     format: dec
                     example: "1"
+        '400':
+          description: Input parameter has failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: body
   /v1/proxy/estimate_gas:
     post:
@@ -1342,6 +1354,12 @@ paths:
                     type: string
                     format: dec
                     example: "21000"
+        '400':
+          description: Input parameter has failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: body
   /v1/proxy/call_contract:
     post:
@@ -1387,6 +1405,12 @@ paths:
                     type: string
                     format: hex
                     example: "0x0"
+        '400':
+          description: Input parameter has failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: body
   /v1/proxy/send_raw_transaction:
     post:
@@ -1425,6 +1449,12 @@ paths:
                     type: string
                     format: hex
                     example: "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
+        '400':
+          description: Input parameter has failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       x-codegen-request-body-name: body
   /v1/blockchain_tip:
     get:


### PR DESCRIPTION
API changes:
* `error_code` and `error_message` are replaced with `code` and `message` respectevely.
* Jsearch API returns `integer` instead of `string` in the spec:

|Property|Affected endpoint|
|---|---|
|`data`|`/v1/accounts/{address}/transaction_count`|
|`Account.nonce`|`/v1/accounts/{address}`|
|`TokenBalance.decimals`|`/v1/accounts/{address}/token_balances`|
|`TokenBalance.decimals`|`/v1/accounts/{address}/token_balance/{contract_address}`|
|`TokenTransfer.decimals`|`/v1/accounts/{address}/token_transfers`|
|`TokenTransfer.decimals`|`/v1/tokens/{contract_address}/transfers`|
|`TokenHolder.balance`|`/v1/tokens/{contract_address}/holders`|
|`TokenHolder.decimals`|`/v1/tokens/{contract_address}/holders`|
|`AssetsSummary.transfersNumber`|`/v1/wallet/assets_summary`|

* Jsearch API returns `boolean` instead of `string` in the spec:

|Property|Affected endpoint|
|---|---|
|`Log.removed`|`/v1/accounts/{address}/logs`|
|`Log.removed`|`/v1/receipts/{txhash}`|

Additions:
* `/v1/verify_contract` endpoint.
* `404` response for `/v1/blockchain_tip`.

Fixes and improvements:
* `meta.blockchainTipStatus.lastUnchangedBlock` is nullable now.
* `paging` items are nullable now.
* `tag` parameter is changed to `tagOptional` for `/v1/accounts/{address}`.
* Response schema for `/v1/accounts/{address}/token_balance/{contract_address}` uses `TokenBalance` instead of `TokenHolder` now.
* `fieldValue` of `/v1/wallet/events` now can be either string or integer.
* `AddressSummary` is wrapped into array for `/v1/wallet/assets_summary`
* `block_number`, `uncle_number`, `timestemp` now can support etiher integers or `latest` keyword.
* Existing `Error` and `Status` schemas  has been reused to form a `ErrorResponse` schema.
