### PR TITLE
ETHBE-768: Fix missing assets for accounts with zero value

### DIFF
--- a/jsearch/api/storage.py
+++ b/jsearch/api/storage.py
@@ -854,9 +854,6 @@ class Storage(DbActionsMixin):
                 if asset['nonce']:
                     nonce = asset['nonce']
 
-                if not asset['value']:
-                    continue
-
                 value = asset['value'] or "0"
                 decimals = asset['decimals'] or "0"
 

--- a/jsearch/api/tests/test_endpoints_wallets.py
+++ b/jsearch/api/tests/test_endpoints_wallets.py
@@ -622,6 +622,7 @@ def create_assets_summaries(
                         'assetsSummary': [
                             {'address': ETHER_ASSET_ADDRESS, 'balance': "300", 'decimals': "0", 'transfersNumber': 0},
                             {'address': 'c1', 'balance': "100", 'decimals': "0", 'transfersNumber': 0},
+                            {'address': 'c100', 'balance': "0", 'decimals': "0", 'transfersNumber': 0},
                             {'address': 'c2', 'balance': "20000", 'decimals': "2", 'transfersNumber': 0}
                         ],
                         'outgoingTransactionsNumber': "10"
@@ -629,6 +630,7 @@ def create_assets_summaries(
                     {
                         'address': 'a2',
                         'assetsSummary': [
+                            {'address': ETHER_ASSET_ADDRESS, 'balance': "0", 'decimals': "0", 'transfersNumber': 0},
                             {'address': 'c1', 'balance': "1000", 'decimals': "1", 'transfersNumber': 0}
                         ],
                         'outgoingTransactionsNumber': "2"
@@ -656,6 +658,18 @@ def create_assets_summaries(
                         ],
                         'outgoingTransactionsNumber': "10"
                     },
+                    {
+                        'address': 'a2',
+                        'assetsSummary': [
+                            {
+                                'address': ETHER_ASSET_ADDRESS,
+                                'balance': "0",
+                                'decimals': "0",
+                                'transfersNumber': 0
+                            },
+                        ],
+                        'outgoingTransactionsNumber': "2"
+                    },
                 ]
         ),
         (
@@ -678,6 +692,18 @@ def create_assets_summaries(
                             },
                         ],
                         'outgoingTransactionsNumber': "10"
+                    },
+                    {
+                        'address': 'a2',
+                        'assetsSummary': [
+                            {
+                                'address': ETHER_ASSET_ADDRESS,
+                                'balance': "0",
+                                'decimals': "0",
+                                'transfersNumber': 0
+                            },
+                        ],
+                        'outgoingTransactionsNumber': "2"
                     },
                 ]
         )


### PR DESCRIPTION
This PR fixes `/v1/wallet/assets_summary` behavior.

From now on, API will return any assets that EOA has interacted with at any time even if its' balance is zero at the moment.

If EOA hasn't interacted with an asset at all (hasn't sent/received any) it won't be shown.