### PR TITLE
ETHBE-776: Fix double hex -> int conversion

### DIFF
--- a/jsearch/common/wallet_events.py
+++ b/jsearch/common/wallet_events.py
@@ -22,7 +22,13 @@ def get_event_type(tx_data: Transaction, is_receiver_contract=False, is_pending=
     """
     Accord to https://jibrelnetwork.atlassian.net/wiki/spaces/JWALLET/pages/769327162/Ethereum+blockchain+events
     """
-    if int(tx_data['value'], 16) != 0:
+    # WTF:
+    #   * `"transactions"."value"` is hex-string
+    #   * `"pending_transactions"."value"` is dec-string
+    value_base = 10 if is_pending else 16
+    value = int(tx_data['value'], value_base)
+
+    if value != 0:
         return WalletEventType.ETH_TRANSFER
 
     if tx_data['to'] == CANCELLATION_ADDRESS:
@@ -243,7 +249,7 @@ def get_event_from_pending_tx(address: str, pending_tx: PendingTransaction) -> O
         event_data = {
             'sender': pending_tx['from'],
             'recipient': pending_tx['to'],
-            'amount': str(int(pending_tx['value'], 16)),
+            'amount': pending_tx['value'],
         }
 
     if event_type:

--- a/jsearch/syncer/tests/processing/test_wallet_events_types_recognition.py
+++ b/jsearch/syncer/tests/processing/test_wallet_events_types_recognition.py
@@ -112,7 +112,7 @@ txs_cases = [
     # - pending transactions
     TransactionCase(
         data={
-            'value': '0x100',
+            'value': '256',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': '0xa5fd1a791c4dfcaacc963d4f73c6ae5824149ea7',
             'input': '0x1a412cd2'
@@ -124,7 +124,7 @@ txs_cases = [
     ),
     TransactionCase(
         data={
-            'value': '0x0',
+            'value': '0',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': CANCELLATION_ADDRESS,
             'input': '0x1a412cd2'
@@ -150,7 +150,7 @@ txs_cases = [
     ),
     TransactionCase(
         data={
-            'value': '0x0',
+            'value': '0',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': '0xa5fd1a791c4dfcaacc963d4f73c6ae5824149ea7',
             'input': '0x23b872dd'
@@ -165,7 +165,7 @@ txs_cases = [
     ),
     TransactionCase(
         data={
-            'value': '0x0',
+            'value': '0',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': '0xa5fd1a791c4dfcaacc963d4f73c6ae5824149ea7',
             'input': '0x1a412cd2'
@@ -177,7 +177,7 @@ txs_cases = [
     ),
     TransactionCase(
         data={
-            'value': '0x2b203d2b8468efff',
+            'value': '3107550999999999999',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': '0xa5fd1a791c4dfcaacc963d4f73c6ae5824149ea7',
             'input': '0x1a412cd2'
@@ -189,7 +189,7 @@ txs_cases = [
     ),
     TransactionCase(
         data={
-            'value': '0x0',
+            'value': '0',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': CANCELLATION_ADDRESS,
             'input': '0x1a412cd2'
@@ -201,7 +201,7 @@ txs_cases = [
     ),
     TransactionCase(
         data={
-            'value': '0x0',
+            'value': '0',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': CANCELLATION_ADDRESS,
             'input': '0x1a412cd2'
@@ -215,7 +215,7 @@ txs_cases = [
     # Target is not a contract
     TransactionCase(
         data={
-            'value': '0x0',
+            'value': '0',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': '0xa5fd1a791c4dfcaacc963d4f73c6ae5824149ea7',
             'input': '0xa9059cbb'
@@ -229,7 +229,7 @@ txs_cases = [
     ),
     TransactionCase(
         data={
-            'value': '0x2b203d2b8468efff',
+            'value': '3107550999999999999',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': '0xa5fd1a791c4dfcaacc963d4f73c6ae5824149ea7',
             'input': '0x1a412cd2'
@@ -241,7 +241,7 @@ txs_cases = [
     ),
     TransactionCase(
         data={
-            'value': '0x0',
+            'value': '0',
             'from': '0x355941cf7ac065310fd4023e1b913209f076a48a',
             'to': CANCELLATION_ADDRESS,
             'input': '0x1a412cd2'

--- a/jsearch/tests/plugins/databases/factories/pending_transactions.py
+++ b/jsearch/tests/plugins/databases/factories/pending_transactions.py
@@ -1,5 +1,6 @@
 from random import randint
-from typing import Optional
+
+from typing import Optional, Any
 
 import factory
 import pytest
@@ -32,7 +33,7 @@ class PendingTransactionFactory(factory.alchemy.SQLAlchemyModelFactory):
     gas_price = factory.Faker('pyint')
     input = '0x00'
     nonce = factory.Sequence(lambda n: n)
-    value = factory.Sequence(lambda n: str(n))
+    value = factory.LazyFunction(lambda: str(randint(0, 999)))
 
     class Meta:
         model = PendingTransactionModel
@@ -41,11 +42,8 @@ class PendingTransactionFactory(factory.alchemy.SQLAlchemyModelFactory):
         rename = {'from_': 'from'}
 
     @classmethod
-    def create_eth_transfer(cls, to=None):
-        value = hex(randint(0, 999))
-        if not to:
-            to = generate_address()
-        return cls.create(value=value, to=to)
+    def create_eth_transfer(cls, **kwargs: Any) -> PendingTransactionModel:
+        return cls.create(**kwargs)
 
     @classmethod
     def create_token_transfer(


### PR DESCRIPTION
This PR fixes an additional API conversion for pending ETH transfers. Pending Syncer already writes TXs' values' as decimals via `HexToDecString` params binder.

```
postgres=# select * from pending_transactions limit 1;
-[ RECORD 1 ]--+-------------------------------------------------------------------
last_synced_id | 315266827
hash           | 0xff483d6b78e713cd37b7d62864f0df82f0d65a7e66eec652b9ef93b3897d3029
status         |
timestamp      | 2019-11-09 12:15:54.757886
removed        | t
node_id        | 0x7c3b15b43fca4f42b5a9ad5b69d18dad1bf80cb91d5ce081c12f2c8fb242e406
r              | 0x509ef74ae2cd85a499158bba7b8e3dab80476507cf320423cd22b76093442671
s              | 0x7810fbe62ef3be105d41796de65a869870d71433e923b9b68472f84a270fbf46
v              | 0x1b
to             | 0x18b8428566ca1565ff55bd1ad9a625f0207c4294
from           | 0xd976d88b05cdfc057bd4bc47dacc12eb05111576
gas            | 21000
gas_price      | 100000000
input          | 0x
nonce          | 2
value          | 27302390000000
id             | 1959452
```