### PR TITLE
Fix performance issue with '/v1/accounts/{address}'

### DIFF
--- a/jsearch/api/database_queries/account_bases.py
+++ b/jsearch/api/database_queries/account_bases.py
@@ -16,4 +16,4 @@ def get_default_fields() -> List[Column]:
 
 
 def get_account_base_query(address: str) -> Query:
-    return select(get_default_fields()).where(accounts_base_t.c.address == address)
+    return select(get_default_fields()).where(accounts_base_t.c.address == address).limit(1)


### PR DESCRIPTION
This PR fixes a performance issue with `/v1/accounts/{address}` endpoint. There's no `UNIQUE` constraint by account's address and, therefore, can be a lot of almost exact rows, related to one account:

```
jsearch_main=# EXPLAIN SELECT accounts_base.address, substring(accounts_base.code, 0, 20), accounts_base.code_hash, accounts_base.last_known_balance, accounts_base.root FROM accounts_base WHERE accounts_base.address = '0xdac17f958d2ee523a2206206994597c13d831ec7';
                                                QUERY PLAN
-----------------------------------------------------------------------------------------------------------
 Index Scan using ix_accounts_base_address on accounts_base  (cost=0.70..2684979.60 rows=666652 width=213)
   Index Cond: ((address)::text = '0xdac17f958d2ee523a2206206994597c13d831ec7'::text)
(2 rows)
```

For Tether token, there're about 600k rows. As a quick and dirty workaround, only the first entry of the set is fetched.
