### PR TITLE
ETHBE-778: Fix Healthcheck API of the 'jsearch-syncer'

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ from aiohttp.test_utils import TestServer, TestClient
 from pathlib import Path
 
 from jsearch.api.app import make_app
+from jsearch.syncer.services.api import make_app as syncer_make_app
 from jsearch.common import logs
 from jsearch.tests.plugins.api import spec_testing_middleware
 
@@ -96,6 +97,14 @@ def cli(loop, aiohttp_client_session_wide):
     client = loop.run_until_complete(aiohttp_client_session_wide(app))
 
     return client
+
+
+@pytest.fixture(scope="session")
+def cli_syncer(loop, aiohttp_client_session_wide):
+    app = syncer_make_app()
+    app['settings'] = {'check_lag': True, 'check_holes': True}
+
+    return loop.run_until_complete(aiohttp_client_session_wide(app))
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/jsearch/api/tests/test_healthcheck.py
+++ b/jsearch/api/tests/test_healthcheck.py
@@ -23,3 +23,23 @@ async def test_healthcheck_everything_is_ok(
         "isNodeHealthy": True,
         "isLoopHealthy": True,
     }
+
+
+async def test_healthcheck_everything_is_ok_syncer(
+        cli_syncer: TestClient,
+        override_settings,
+):
+    override_settings('VERSION', '1.0.0-app-version')
+
+    result = await cli_syncer.get('/healthcheck', json=dict())
+
+    assert result.status == 200
+    assert await result.json() == {
+        "healthy": True,
+        "version": '1.0.0-app-version',
+        "isMainDbHealthy": True,
+        "isLoopHealthy": True,
+        "isChainHealthy": True,
+        "isLagHealthy": True,
+        "isRawDbHealthy": True
+    }


### PR DESCRIPTION
This PR fixes `aiopg` interface usage. Also, the positive test for the Blocks Syncer Healtcheck API has been added.