### PR TITLE
Fix error due to reapplying chain splits.

### DIFF
--- a/jsearch/syncer/database/main.py
+++ b/jsearch/syncer/database/main.py
@@ -350,12 +350,15 @@ class MainDB(DBWrapper):
         await connection.execute("""DELETE FROM uncles WHERE block_hash=%s""", block_hash)
         await connection.execute("""DELETE FROM blocks WHERE hash=%s""", block_hash)
 
-    async def get_block_hash_by_number(self, block_num):
+    async def get_block_hash_by_number(self, block_num) -> Optional[str]:
         q = blocks_t.select().where(and_(blocks_t.c.number == block_num, blocks_t.c.is_forked == false()))
         async with self.engine.acquire() as conn:
             res = await conn.execute(q)
             row = await res.fetchone()
-            return row['hash']
+            if row:
+                return row['hash']
+
+        return None
 
     async def is_contract_address(self, addresses):
         contracts_addresses = []

--- a/jsearch/syncer/manager.py
+++ b/jsearch/syncer/manager.py
@@ -172,15 +172,18 @@ class Manager:
     async def rewrite_block(self, block_number):
         logger.info("Rewrite block", extra={'block_number': block_number})
         block_hash = await self.main_db.get_block_hash_by_number(block_number)
-        await sync_block(
-            raw_db=self.raw_db,
-            main_db=self.main_db,
-            block_hash=block_hash,
-            block_number=block_number,
-            is_forked=False,
-            chain_event=None,
-            rewrite=True
-        )
+        if block_hash is None:
+            logger.info('Block is missed, use the syncer to sync it', extra={'number': block_number})
+        else:
+            await sync_block(
+                raw_db=self.raw_db,
+                main_db=self.main_db,
+                block_hash=block_hash,
+                block_number=block_number,
+                is_forked=False,
+                chain_event=None,
+                rewrite=True
+            )
 
     @timeit('[SYNCER] Reapply splits')
     async def reapply_splits(self, block_range: BlockRange) -> None:

--- a/jsearch/syncer/syncer.py
+++ b/jsearch/syncer/syncer.py
@@ -70,8 +70,8 @@ async def sync_block(
         block_number: Optional[int] = None,
         is_forked: bool = False,
         chain_event: Optional[Dict[str, Any]] = None,
-        rewrite: Optional[bool] = False
-) -> Optional[bool]:
+        rewrite: Optional[bool] = False,
+) -> Optional[Dict[str, Any]]:
     data = await load_block_from_raw_db(
         raw_db=raw_db,
         block_hash=block_hash,
@@ -81,7 +81,7 @@ async def sync_block(
     if data:
         block = await process_block(main_db, data)
         await main_db.write_block(chain_event, block, rewrite)
-        return True
+        return block.block
 
     return None
 


### PR DESCRIPTION
If block is missed - then need to load it, sync it and return
block bodies.